### PR TITLE
fix: CLIN-1092 Separer colonne transcrit en 2

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
   "condition": "Condition",
   "deletion": "Deletion",
   "duplication": "Duplication",
+  "ensemblID": "Ensembl ID",
   "family": "family",
   "father": "father",
   "female": "Female",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,6 +16,7 @@
   "condition": "Condition",
   "deletion": "Délétion",
   "duplication": "Duplication",
+  "ensemblID": "Ensembl ID",
   "family": "famille",
   "father": "père",
   "female": "Femme",

--- a/src/views/Variants/Entity/SummaryPanel/Consequences/index.tsx
+++ b/src/views/Variants/Entity/SummaryPanel/Consequences/index.tsx
@@ -267,36 +267,33 @@ const columns = [
       conservation == null ? TABLE_EMPTY_PLACE_HOLDER : conservation,
   },
   {
-    title: () => intl.get('transcript'),
+    title: () => intl.get('ensemblID'),
     dataIndex: 'transcript',
-    render: (transcript: { ids: string[]; transcriptId: string; isCanonical?: boolean }) => {
-      if (!transcript.ids || transcript.ids.length === 0) {
-        return (
-          <div className={styles.transcriptId}>
-            {transcript.transcriptId}
-            {transcript.isCanonical && (
-              <CanonicalIcon className={styles.canonicalIcon} height="14" width="14" />
-            )}
-          </div>
-        );
-      }
-
-      return transcript.ids.map((id) => (
+    render: (transcript: { transcriptId: string; isCanonical?: boolean }) => (
+      <div className={styles.transcriptId}>
+        {transcript.transcriptId}
+        {transcript.isCanonical && (
+          <CanonicalIcon className={styles.canonicalIcon} height="14" width="14" />
+        )}
+      </div>
+    ),
+    width: '15%',
+  },
+  {
+    title: () => intl.get('refSeq'),
+    dataIndex: 'transcript',
+    render: (transcript: { ids: string[] }) =>
+      transcript?.ids?.map((id) => (
         <div key={id} className={styles.transcriptId}>
-          {`${transcript.transcriptId} / `}
           <ExternalLink
             href={`https://www.ncbi.nlm.nih.gov/nuccore/${id}?report=graph`}
             className={styles.transcriptLink}
           >
             {id}
-            {transcript.isCanonical && (
-              <CanonicalIcon className={styles.canonicalIcon} height="14" width="14" />
-            )}
           </ExternalLink>
         </div>
-      ));
-    },
-    width: '20%',
+      )) || TABLE_EMPTY_PLACE_HOLDER,
+    width: '15%',
   },
 ];
 


### PR DESCRIPTION
Avant : 
![image](https://user-images.githubusercontent.com/52966302/171215189-ff775ffc-5ea8-4370-9fc0-fab5d409a235.png)

Après:
![image](https://user-images.githubusercontent.com/52966302/171215290-9ed56d95-4f53-4835-8e42-6a88de56614d.png)

