### PR TITLE
refactor: CLIN-1104 optimize pie charts data computation

### DIFF
--- a/src/views/Variants/Entity/PatientPanel/index.tsx
+++ b/src/views/Variants/Entity/PatientPanel/index.tsx
@@ -79,7 +79,7 @@ const updateSlices = (id: string, slices: DefaultRawDatum[]) =>
           value: (slices.find((s) => s.id === id)?.value ?? 0) + 1,
         },
       ]
-    : [...slices];
+    : slices;
 
 const computePieSlices = (data: DataSourceState) =>
   (data?.hits?.edges || []).reduce(


### PR DESCRIPTION
you can test here http://localhost:2005/variant/entity/10-100296259-G-A/patients
- avoid importing all of lodash (`import _ from "lodash"`)
- compute data for all charts by traversing data only once (a gain factor of 5X on my machine)