### PR TITLE
fix: CLIN-1151 update prescription search design fix

### DIFF
--- a/src/views/Prescriptions/Search/index.tsx
+++ b/src/views/Prescriptions/Search/index.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import intl from 'react-intl-universal';
 import { MedicineBoxOutlined, SolutionOutlined } from '@ant-design/icons';
+import ProLabel from '@ferlab/ui/core/components/ProLabel';
 import useQueryBuilderState from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { ISqonGroupFilter, ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
 import { resolveSyntheticSqon } from '@ferlab/ui/core/data/sqon/utils';
-import { Space, Tabs, Typography } from 'antd';
+import { Space, Tabs } from 'antd';
 import { usePrescription, usePrescriptionMapping } from 'graphql/prescriptions/actions';
 import { useSequencingRequests } from 'graphql/sequencing/actions';
 import { isEmpty } from 'lodash';
@@ -25,8 +26,6 @@ import styles from './index.module.scss';
 
 export const DEFAULT_PAGE_SIZE = 20;
 export const DEFAULT_PAGE = 1;
-
-const Text = Typography.Text;
 
 const DEFAULT_QUERY_CONFIG: IQueryConfig = {
   pageIndex: DEFAULT_PAGE,
@@ -82,7 +81,7 @@ const PrescriptionSearch = (): React.ReactElement => {
       <ScrollContentWithFooter scrollId={PRESCRIPTION_SCROLL_ID}>
         <Space direction="vertical" size="middle" className={styles.patientContentContainer}>
           <div className={styles.patientContentHeader}>
-            <Text strong>{intl.get('home.prescription.search.box.label')}</Text>
+            <ProLabel title={intl.get('home.prescription.search.box.label')} colon />
             <PrescriptionAutoComplete />
           </div>
           <Tabs type="card">


### PR DESCRIPTION
ajouter `:` au label de la recherche.
![Screen Shot 2022-06-08 at 11 28 33 PM](https://user-images.githubusercontent.com/98903/172758121-4d0f2e49-63b1-4567-9c29-7839283f2761.png)

