### PR TITLE
fix: CLIN-1182 make sure apollo client cache some results

### DIFF
--- a/src/graphql/prescriptions/actions.tsx
+++ b/src/graphql/prescriptions/actions.tsx
@@ -64,6 +64,7 @@ export const useTaskEntity = (
 
 export const usePrescriptionMapping = (): ExtendedMappingResults => {
   const { loading, result } = useLazyResultQuery<any>(INDEX_EXTENDED_MAPPING('Analyses'), {
+    fetchPolicy: 'no-cache',
     variables: [],
   });
 

--- a/src/graphql/prescriptions/queries.tsx
+++ b/src/graphql/prescriptions/queries.tsx
@@ -35,31 +35,6 @@ export const PRESCRIPTIONS_QUERY = gql`
   }
 `;
 
-export const PRESCRIPTIONS_ENTITY_QUERY = gql`
-  query PrescriptionsEntity($sqon: JSON, $first: Int, $offset: Int, $sort: [Sort]) {
-    Analyses {
-      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort) {
-        edges {
-          node {
-            id
-            patient_id
-            patient_mrn
-            prescription_id
-            ep
-            created_on
-            timestamp
-            requester
-            ldm
-            analysis_code
-            status
-          }
-        }
-        total
-      }
-    }
-  }
-`;
-
 export const PRESCRIPTIONS_SEARCH_QUERY = gql`
   query AnalysisSearch($sqon: JSON, $first: Int, $offset: Int) {
     Analyses {

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -20,7 +20,7 @@ export type QueryVariable = {
 };
 
 export const INDEX_EXTENDED_MAPPING = (index: string) => gql`
-query ExtendedMapping {
+query ExtendedMapping${index} {
   ${index} {
     extended
   }

--- a/src/hooks/graphql/useGetExtendedMappings.ts
+++ b/src/hooks/graphql/useGetExtendedMappings.ts
@@ -4,7 +4,9 @@ import { INDEX_EXTENDED_MAPPING } from 'graphql/queries';
 import { useLazyResultQueryOnLoadOnly } from 'hooks/graphql/useLazyResultQuery';
 
 const useGetExtendedMappings = (index: string): ExtendedMappingResults => {
-  const { loading, result } = useLazyResultQueryOnLoadOnly<any>(INDEX_EXTENDED_MAPPING(index));
+  const { loading, result } = useLazyResultQueryOnLoadOnly<any>(INDEX_EXTENDED_MAPPING(index), {
+    fetchPolicy: 'no-cache',
+  });
 
   return {
     loading,


### PR DESCRIPTION
Some local no-so-rigourous-metrics:

with this commit (new instances created multiple times)
ApolloProvider.tsx:63 test: 0.007080078125 ms
ApolloProvider.tsx:63 test: 0.007080078125 ms
ApolloProvider.tsx:63 test: 0.005859375 ms
ApolloProvider.tsx:63 test: 0.009033203125 ms
ApolloProvider.tsx:63 test: 0.005859375 ms
ApolloProvider.tsx:63 test: 0.008056640625 ms
ApolloProvider.tsx:63 test: 0.004150390625 ms
ApolloProvider.tsx:63 test: 0.01220703125 ms
ApolloProvider.tsx:63 test: 0.012939453125 ms

before this commit (one instances per backend) 
test2: 2.27001953125 ms
ApolloProvider.tsx:54 test2: 0.181884765625 ms
ApolloProvider.tsx:54 test2: 0.34521484375 ms
ApolloProvider.tsx:54 test2: 0.277099609375 ms
ApolloProvider.tsx:54 test2: 0.2080078125 ms
ApolloProvider.tsx:54 test2: 0.14111328125 ms
ApolloProvider.tsx:54 test2: 0.123779296875 ms
ApolloProvider.tsx:54 test2: 0.087158203125 ms

Observations: cache now works for certain queries but not for all (disabled for extended mappings). A lot of room for improvment.