### PR TITLE
feat: CLIN-1247 search gene case sensitive

### DIFF
--- a/src/views/Snv/components/GeneUploadIds/index.tsx
+++ b/src/views/Snv/components/GeneUploadIds/index.tsx
@@ -72,7 +72,7 @@ const GenesUploadIds = ({ queryBuilderId }: OwnProps) => (
       const matchResults = ids.map((id, index) => {
         const upperCaseId = id.toUpperCase();
         const gene = genes.find((gene) =>
-          [gene.symbol, gene.ensembl_gene_id].includes(upperCaseId),
+          [gene.symbol?.toUpperCase(), gene.ensembl_gene_id?.toUpperCase()].includes(upperCaseId),
         );
         return gene
           ? {

--- a/src/views/Snv/components/GeneUploadIds/index.tsx
+++ b/src/views/Snv/components/GeneUploadIds/index.tsx
@@ -70,7 +70,10 @@ const GenesUploadIds = ({ queryBuilderId }: OwnProps) => (
       const genes: GeneEntity[] = hydrateResults(response.data?.data?.Genes?.hits?.edges || []);
 
       const matchResults = ids.map((id, index) => {
-        const gene = genes.find((gene) => [gene.symbol, gene.ensembl_gene_id].includes(id));
+        const upperCaseId = id.toUpperCase();
+        const gene = genes.find((gene) =>
+          [gene.symbol, gene.ensembl_gene_id].includes(upperCaseId),
+        );
         return gene
           ? {
               key: index.toString(),


### PR DESCRIPTION
Linked to: https://github.com/Ferlab-Ste-Justine/clin-variant-etl/pull/213 (where the case un-sensitive stuff is done)

The change in front-end is only the after request when the UI compute a list of found genes from the response.