### PR TITLE
fix: CLIN-1472 affichage origineParental variant

### DIFF
--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -285,12 +285,10 @@ export const getVariantColumns = (
         title: intl.get('po'),
         tooltip: intl.get('parental.origin'),
         defaultHidden: true,
-        render: (record: VariantEntity) => {
-          const donor = findDonorById(record.donors, patientId);
-          return donor?.parental_origin
-            ? capitalize(intl.get(donor?.parental_origin))
-            : TABLE_EMPTY_PLACE_HOLDER;
-        },
+        render: (record: VariantEntity) =>
+          removeUnderscoreAndCapitalize(
+            findDonorById(record.donors, patientId)?.parental_origin! || '',
+          ).defaultMessage(TABLE_EMPTY_PLACE_HOLDER),
       },
       {
         key: 'alt',

--- a/src/views/Snv/components/OccurrenceDrawer/index.tsx
+++ b/src/views/Snv/components/OccurrenceDrawer/index.tsx
@@ -188,9 +188,9 @@ const OccurrenceDrawer = ({
                 )}
               </Descriptions.Item>
               <Descriptions.Item label={intl.get('screen.patientsnv.drawer.parental.origin')}>
-                {donor?.parental_origin
-                  ? capitalize(donor?.parental_origin)
-                  : TABLE_EMPTY_PLACE_HOLDER}
+                {removeUnderscoreAndCapitalize(donor?.parental_origin || '').defaultMessage(
+                  TABLE_EMPTY_PLACE_HOLDER,
+                )}
               </Descriptions.Item>
             </Descriptions>
           )}


### PR DESCRIPTION
- fix affichage manquant dans la colonne origine parental snv
- Afficher correctement la valeur origine parental dans le tiroir des occurrences