### PR TITLE
feat: CLIN-1501 distinct consequences

### DIFF
--- a/src/views/Snv/components/ConsequencesCell/consequences.ts
+++ b/src/views/Snv/components/ConsequencesCell/consequences.ts
@@ -35,6 +35,22 @@ type SymbolToConsequences = {
   [key: string]: ArrangerEdge<ConsequenceEntity>[];
 };
 
+export const distinctConsequences = (consequences: ArrangerEdge<ConsequenceEntity>[]) => {
+  const uniqueKeys: String[] = [];
+  return consequences.filter((c) => {
+    // ignore empty consequence
+    const consequence = c.node?.consequences?.[0];
+    if (!consequence) return false;
+    // compute unicity key
+    const symbol = c.node?.symbol || keyNoSymbol;
+    const keyForCurrentConsequence = `${symbol}_${consequence}`;
+    // filter consequence based on key
+    const isUnique = !uniqueKeys.includes(keyForCurrentConsequence);
+    if (isUnique) uniqueKeys.push(keyForCurrentConsequence);
+    return isUnique;
+  });
+};
+
 export const generateConsequencesDataLines = (
   rawConsequences: ArrangerEdge<ConsequenceEntity>[] | null,
 ): ArrangerEdge<ConsequenceEntity>[] => {
@@ -54,7 +70,7 @@ export const generateConsequencesDataLines = (
     {},
   );
 
-  return Object.entries(symbolToConsequences).reduce(
+  const consequences = Object.entries(symbolToConsequences).reduce(
     (acc: ArrangerEdge<ConsequenceEntity>[], [key, consequences]) => {
       // no gene then show
       if (key === keyNoSymbol) {
@@ -66,4 +82,6 @@ export const generateConsequencesDataLines = (
     },
     [],
   );
+
+  return distinctConsequences(consequences);
 };

--- a/src/views/Snv/components/ConsequencesCell/tests/consequences.spec.js
+++ b/src/views/Snv/components/ConsequencesCell/tests/consequences.spec.js
@@ -1,0 +1,136 @@
+import { generateConsequencesDataLines } from '../consequences';
+
+describe('consequences: generateConsequencesDataLines', () => {
+  test('Should be robust', () => {
+    expect(generateConsequencesDataLines(null)).toEqual([]);
+    expect(generateConsequencesDataLines([])).toEqual([]);
+  });
+
+  test('Should keep the better impact score', () => {
+    const consequences = [
+      {
+        node: {
+          symbol: 's1',
+          impact_score: 1,
+          consequences: ['c1'],
+        },
+      },
+      {
+        node: {
+          symbol: 's1',
+          impact_score: 2,
+          consequences: ['c1'],
+        },
+      },
+    ];
+
+    const expected = [
+      {
+        node: {
+          symbol: 's1',
+          impact_score: 2,
+          consequences: ['c1'],
+        },
+      },
+    ];
+
+    expect(generateConsequencesDataLines(consequences)).toEqual(expected);
+  });
+
+  test('Should return distinct (with higher score) consequences', () => {
+    const consequences = [
+      {
+        node: {
+          symbol: 's1',
+          impact_score: 1,
+          consequences: ['c1'],
+        },
+      },
+      {
+        node: {
+          symbol: 's1',
+          impact_score: 2,
+          consequences: ['c1'],
+        },
+      },
+    ];
+
+    const expected = [
+      {
+        node: {
+          symbol: 's1',
+          impact_score: 2,
+          consequences: ['c1'],
+        },
+      },
+    ];
+
+    expect(generateConsequencesDataLines(consequences)).toEqual(expected);
+  });
+
+  test('Should ignore empty consequences', () => {
+    const consequences = [
+      {
+        node: {
+          consequences: [],
+        },
+      },
+    ];
+
+    const expected = [];
+
+    expect(generateConsequencesDataLines(consequences)).toEqual(expected);
+  });
+
+  test('Should group by symbol', () => {
+    const consequences = [
+      {
+        node: {
+          symbol: 's1',
+          consequences: ['c1'],
+        },
+      },
+      {
+        node: {
+          symbol: 's1',
+          consequences: ['c3'],
+        },
+      },
+      {
+        node: {
+          symbol: 's2',
+          consequences: ['c2'],
+        },
+      },
+      {
+        node: {
+          // no symbol
+          consequences: ['c3'],
+        },
+      },
+    ];
+
+    const expected = [
+      {
+        node: {
+          symbol: 's1',
+          consequences: ['c1'],
+        },
+      },
+      {
+        node: {
+          symbol: 's2',
+          consequences: ['c2'],
+        },
+      },
+      {
+        node: {
+          // no symbol
+          consequences: ['c3'],
+        },
+      },
+    ];
+
+    expect(generateConsequencesDataLines(consequences)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Fix this issue: https://ferlab-crsj.atlassian.net/browse/CLIN-1501

This issue seems related to `symbol = null` we can have the same consequence multiple times.

The fix will guaranty unicity for all symbols