### PR TITLE
feat: CLIN-1480 mettre colonne Actions figer a droite

### DIFF
--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -191,6 +191,7 @@ export const getVariantColumns = (
         className: style.userAffectedBtnCell,
         key: 'actions',
         title: intl.get('screen.patientsnv.results.table.actions'),
+        fixed: 'right',
         render: (record: VariantEntity) => (
           <Space align={'center'}>
             <Tooltip title={intl.get('occurrence.patient')}>


### PR DESCRIPTION
- Mettre la colonne actions figer a droite


Avant
![image](https://user-images.githubusercontent.com/52966302/199331200-ce3c574a-705f-43c7-8508-05e6f33740c0.png)

Maintenant
![image](https://user-images.githubusercontent.com/52966302/199331047-f6fcb1b4-d433-443c-90ee-c9852b0a2749.png)

@kstonge 
