### PR TITLE
feat: CLIN-1072 - filter  variants suggestions

### DIFF
--- a/src/api/arranger/models.ts
+++ b/src/api/arranger/models.ts
@@ -6,7 +6,7 @@ export enum SuggestionType {
 }
 
 export enum GenomicFeatureType {
-  Variant = 'variant',
+  VARIANT = 'variant',
   GENE = 'gene',
 }
 
@@ -20,6 +20,7 @@ export type Suggestion = {
   symbol?: string;
   rsnumber?: string;
   ensembl_gene_id?: string;
+  suggest: [{ input: string[]; weight: number }];
 };
 
 export type SelectedSuggestion = {

--- a/src/utils/suggestions.ts
+++ b/src/utils/suggestions.ts
@@ -1,0 +1,13 @@
+import { GenomicFeatureType, Suggestion } from 'api/arranger/models';
+
+export const filterByTypeAndWeight = (
+  suggestions: Suggestion[],
+  type: GenomicFeatureType,
+  minWeight: number = 0,
+): Suggestion[] =>
+  suggestions?.filter(
+    (s) =>
+      s.type === type &&
+      s.suggest?.length > 0 &&
+      s.suggest.some((i) => i.input?.length > 0 && i.weight >= minWeight),
+  ) ?? [];

--- a/src/utils/tests/suggestions.spec.js
+++ b/src/utils/tests/suggestions.spec.js
@@ -1,0 +1,110 @@
+import { filterByTypeAndWeight } from 'utils/suggestions';
+
+describe('filterByTypeAndWeight', () => {
+  test('Should be robust', () => {
+    expect(filterByTypeAndWeight(null, null)).toEqual([]);
+    expect(filterByTypeAndWeight([], null)).toEqual([]);
+  });
+  test('Should filter by type and default min weight (=0)', () => {
+    const suggestions = [
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 0,
+            input: ['foo'],
+          },
+        ],
+      },
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: -1, // weight to low
+            input: ['foo'],
+          },
+        ],
+      },
+      {
+        type: 'gene', // bad type
+      },
+      {
+        type: 'variant',
+        // missing suggest
+      },
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 0,
+            // missing input
+          },
+        ],
+      },
+    ];
+    const expected = [
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 0,
+            input: ['foo'],
+          },
+        ],
+      },
+    ];
+    expect(filterByTypeAndWeight(suggestions, 'variant')).toEqual(expected);
+  });
+  test('Should filter by type and custom min weight', () => {
+    const suggestions = [
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 0,
+            input: ['foo'],
+          },
+        ],
+      },
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 2,
+            input: ['foo'],
+          },
+        ],
+      },
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 4,
+            input: ['foo'],
+          },
+        ],
+      },
+    ];
+    const expected = [
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 2,
+            input: ['foo'],
+          },
+        ],
+      },
+      {
+        type: 'variant',
+        suggest: [
+          {
+            weight: 4,
+            input: ['foo'],
+          },
+        ],
+      },
+    ];
+    expect(filterByTypeAndWeight(suggestions, 'variant', 2)).toEqual(expected);
+  });
+});

--- a/src/views/Home/components/VariantSearchBox/index.tsx
+++ b/src/views/Home/components/VariantSearchBox/index.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import intl from 'react-intl-universal';
 import { Link, useHistory } from 'react-router-dom';
 import { ArrangerApi } from 'api/arranger';
-import { Suggestion, SuggestionType } from 'api/arranger/models';
+import { GenomicFeatureType, Suggestion, SuggestionType } from 'api/arranger/models';
 import { isEmpty } from 'lodash';
 import OptionItem from 'views/Snv/components/VariantGeneSearch/OptionItem';
 
 import LineStyleIcon from 'components/icons/LineStyleIcon';
+import { filterByTypeAndWeight } from 'utils/suggestions';
 
 import SearchBox from '../SearchBox';
 
@@ -28,7 +29,9 @@ const VariantSearchBox = () => {
         onChange: async (value) => {
           if (value) {
             const { data } = await ArrangerApi.searchSuggestions(SuggestionType.VARIANTS, value);
-            setSuggestions(data?.suggestions ?? []);
+            setSuggestions(
+              filterByTypeAndWeight(data?.suggestions ?? [], GenomicFeatureType.VARIANT, 4),
+            );
           }
         },
         onKeyDown: (e) => {


### PR DESCRIPTION
Example of suggestion:
```
"type": "variant",
"suggest": [
                        {
                            "weight": 4,
                            "input": [
                                "chr1:g.156530566G>C",
                                "rs732362",
                                "1-156530566-G-C"
                            ]
                        },
                        {
                            "weight": 2,
                            "input": [
                                "IQGAP3",
                                "ENST00000361170",
                                "ENSG00000183856"
                            ]
                        }
                    ],
```
We want to ignore what's linked to genes, in the ETL this part has been put inside the weight 2 section.
Solution: filter and keep the weight >= 4 matchs