### PR TITLE
feat: CLIN-1550 - export as TSV - with all

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -21,10 +21,10 @@ export const toKebabCase = (str: string) => {
 export const formatTimestampToISODate = (timestamp: number) =>
   new Date(timestamp).toISOString().split('T')[0];
 
-export const downloadText = (text: string, filename: string, type = ' text/csv') => {
+export const downloadText = (text: string, filename: string, contentType = ' text/plain') => {
   if (text && text.length > 0) {
     const byteArray = new TextEncoder().encode(text);
-    const blob = new Blob([byteArray], { type: type });
+    const blob = new Blob([byteArray], { type: contentType });
     downloadFile(blob, filename);
   }
 };

--- a/src/utils/searchPageTypes.ts
+++ b/src/utils/searchPageTypes.ts
@@ -9,6 +9,8 @@ export type TPagingConfigCb = (config: TPagingConfig) => void;
 
 export type TQueryConfigCb = (config: IQueryConfig) => void;
 
+export type TDownload = (keys: string[]) => void;
+
 export interface IQueryConfig {
   pageIndex: number;
   size: number;

--- a/src/views/Prescriptions/Search/components/table/PrescriptionTable/index.tsx
+++ b/src/views/Prescriptions/Search/components/table/PrescriptionTable/index.tsx
@@ -5,16 +5,12 @@ import { GqlResults } from 'graphql/models';
 import { AnalysisResult, ITableAnalysisResult } from 'graphql/prescriptions/models/Prescription';
 import { DEFAULT_PAGE_SIZE } from 'views/Prescriptions/Search';
 import { PRESCRIPTION_SCROLL_ID } from 'views/Prescriptions/Search/utils/contstant';
-import {
-  exportAsTSV,
-  extractSelectionFromResults,
-  makeFilenameDatePart,
-} from 'views/Prescriptions/utils/export';
+import { ALL_KEYS } from 'views/Prescriptions/utils/export';
 
 import { useUser } from 'store/user';
 import { updateConfig } from 'store/user/thunks';
-import { downloadText, formatQuerySortList, scrollToTop } from 'utils/helper';
-import { IQueryConfig, TQueryConfigCb } from 'utils/searchPageTypes';
+import { formatQuerySortList, scrollToTop } from 'utils/helper';
+import { IQueryConfig, TDownload, TQueryConfigCb } from 'utils/searchPageTypes';
 import { getProTableDictionary } from 'utils/translation';
 
 import { prescriptionsColumns } from './columns';
@@ -27,21 +23,14 @@ interface OwnProps {
   extra?: React.ReactElement;
   loading?: boolean;
   setQueryConfig: TQueryConfigCb;
+  setDownloadKeys: TDownload;
   queryConfig: IQueryConfig;
 }
-
-const download = (results: GqlResults<AnalysisResult> | null, selectedKeys: string[]) => {
-  if (results) {
-    const data = extractSelectionFromResults(results.data, selectedKeys, 'prescription_id');
-    const headers = prescriptionsColumns().map((c) => c.key);
-    const tsv = exportAsTSV(data, headers);
-    downloadText(tsv, `PR_${makeFilenameDatePart()}.tsv`);
-  }
-};
 
 const PrescriptionsTable = ({
   results,
   setQueryConfig,
+  setDownloadKeys,
   queryConfig,
   loading = false,
 }: OwnProps): React.ReactElement => {
@@ -77,12 +66,19 @@ const PrescriptionsTable = ({
           total: results?.total || 0,
         },
         enableColumnSort: true,
-        onSelectedRowsChange: (e) => {
-          setSelectedKeys(e);
+        onSelectedRowsChange: (keys) => {
+          setSelectedKeys(keys);
+        },
+        onSelectAllResultsChange: () => {
+          setSelectedKeys([ALL_KEYS]);
         },
         enableTableExport: true,
         onTableExportClick: () => {
-          download(results, selectedKeys);
+          if (selectedKeys.length === 0) {
+            setDownloadKeys([ALL_KEYS]);
+          } else {
+            setDownloadKeys(selectedKeys);
+          }
         },
         onColumnSortChange: (columns) => {
           dispatch(

--- a/src/views/Prescriptions/Search/index.tsx
+++ b/src/views/Prescriptions/Search/index.tsx
@@ -51,6 +51,9 @@ const DEFAULT_SORT = [
     field: 'created_on',
     order: 'desc',
   },
+];
+
+const ID_SORT = [
   {
     field: '_id',
     order: 'desc',
@@ -88,6 +91,14 @@ const PrescriptionSearch = (): React.ReactElement => {
   const [downloadSequencingKeys, setDownloadSequencingKeys] = useState<string[]>([]);
   const sequencingActiveQuery = setPrescriptionStatusInActiveQuery(activeQuery);
 
+  const sequencingsSort = isEmpty(sequencingQueryConfig.sort)
+    ? [...DEFAULT_SORT, ...ID_SORT]
+    : [...sequencingQueryConfig.sort, ...ID_SORT];
+
+  const prescriptionsSort = isEmpty(prescriptionQueryConfig.sort)
+    ? [...DEFAULT_SORT, ...ID_SORT]
+    : [...prescriptionQueryConfig.sort, ...ID_SORT];
+
   const sequencings = useSequencingRequests({
     first: sequencingQueryConfig.size,
     offset: sequencingQueryConfig.size * (sequencingQueryConfig.pageIndex - 1),
@@ -99,7 +110,7 @@ const PrescriptionSearch = (): React.ReactElement => {
           : generateMultipleQuery(searchValue, sequencingActiveQuery),
       ),
     ),
-    sort: isEmpty(sequencingQueryConfig.sort) ? DEFAULT_SORT : sequencingQueryConfig.sort,
+    sort: sequencingsSort,
   });
 
   const prescriptions = usePrescription({
@@ -109,7 +120,7 @@ const PrescriptionSearch = (): React.ReactElement => {
       queryList,
       searchValue.length === 0 ? activeQuery : generateMultipleQuery(searchValue, activeQuery),
     ),
-    sort: isEmpty(prescriptionQueryConfig.sort) ? DEFAULT_SORT : prescriptionQueryConfig.sort,
+    sort: prescriptionsSort,
   });
 
   // query is always done, unfortunately but response size is limited if nothing to download
@@ -120,7 +131,7 @@ const PrescriptionSearch = (): React.ReactElement => {
       queryList,
       searchValue.length === 0 ? activeQuery : generateMultipleQuery(searchValue, activeQuery),
     ),
-    sort: isEmpty(prescriptionQueryConfig.sort) ? DEFAULT_SORT : prescriptionQueryConfig.sort,
+    sort: prescriptionsSort,
   });
 
   // query is always done, unfortunately but response size is limited if nothing to download
@@ -135,7 +146,7 @@ const PrescriptionSearch = (): React.ReactElement => {
           : generateMultipleQuery(searchValue, sequencingActiveQuery),
       ),
     ),
-    sort: isEmpty(sequencingQueryConfig.sort) ? DEFAULT_SORT : sequencingQueryConfig.sort,
+    sort: sequencingsSort,
   });
 
   useEffect(() => {

--- a/src/views/Prescriptions/Search/index.tsx
+++ b/src/views/Prescriptions/Search/index.tsx
@@ -51,6 +51,10 @@ const DEFAULT_SORT = [
     field: 'created_on',
     order: 'desc',
   },
+  {
+    field: '_id',
+    order: 'desc',
+  },
 ];
 
 const adjustSqon = (sqon: ISyntheticSqon) =>

--- a/src/views/Prescriptions/Search/index.tsx
+++ b/src/views/Prescriptions/Search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { MedicineBoxOutlined, SolutionOutlined } from '@ant-design/icons';
 import ProLabel from '@ferlab/ui/core/components/ProLabel';
@@ -29,6 +29,11 @@ import { commonPrescriptionFilterFields } from 'views/Prescriptions/utils/consta
 import ContentWithHeader from 'components/Layout/ContentWithHeader';
 import ScrollContentWithFooter from 'components/Layout/ScrollContentWithFooter';
 import { IQueryConfig } from 'utils/searchPageTypes';
+
+import { downloadAsTSV } from '../utils/export';
+
+import { prescriptionsColumns } from './components/table/PrescriptionTable/columns';
+import { sequencingsColumns } from './components/table/SequencingTable/columns';
 
 import styles from './index.module.scss';
 
@@ -75,7 +80,10 @@ const PrescriptionSearch = (): React.ReactElement => {
   const [prescriptionQueryConfig, setPrescriptionQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
   const [sequencingQueryConfig, setSequencingQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
   const [searchValue, setSearchValue] = useState('');
+  const [downloadPrescriptionKeys, setDownloadPrescriptionKeys] = useState<string[]>([]);
+  const [downloadSequencingKeys, setDownloadSequencingKeys] = useState<string[]>([]);
   const sequencingActiveQuery = setPrescriptionStatusInActiveQuery(activeQuery);
+
   const sequencings = useSequencingRequests({
     first: sequencingQueryConfig.size,
     offset: sequencingQueryConfig.size * (sequencingQueryConfig.pageIndex - 1),
@@ -99,6 +107,61 @@ const PrescriptionSearch = (): React.ReactElement => {
     ),
     sort: isEmpty(prescriptionQueryConfig.sort) ? DEFAULT_SORT : prescriptionQueryConfig.sort,
   });
+
+  // query is always done, unfortunately but response size is limited if nothing to download
+  const prescriptionsToDownload = usePrescription({
+    first: downloadPrescriptionKeys.length > 0 ? prescriptions.total : 0,
+    offset: 0,
+    sqon: resolveSyntheticSqon(
+      queryList,
+      searchValue.length === 0 ? activeQuery : generateMultipleQuery(searchValue, activeQuery),
+    ),
+    sort: isEmpty(prescriptionQueryConfig.sort) ? DEFAULT_SORT : prescriptionQueryConfig.sort,
+  });
+
+  // query is always done, unfortunately but response size is limited if nothing to download
+  const sequencingsToDownload = useSequencingRequests({
+    first: downloadSequencingKeys.length > 0 ? sequencings.total : 0,
+    offset: 0,
+    sqon: adjustSqon(
+      resolveSyntheticSqon(
+        queryList,
+        searchValue.length === 0
+          ? sequencingActiveQuery
+          : generateMultipleQuery(searchValue, sequencingActiveQuery),
+      ),
+    ),
+    sort: isEmpty(sequencingQueryConfig.sort) ? DEFAULT_SORT : sequencingQueryConfig.sort,
+  });
+
+  useEffect(() => {
+    // download only when both prescriptionsToDownload and something to download
+    if (downloadPrescriptionKeys.length > 0 && prescriptionsToDownload.data.length > 0) {
+      downloadAsTSV(
+        prescriptionsToDownload.data,
+        downloadPrescriptionKeys,
+        'prescription_id',
+        prescriptionsColumns(),
+        'PR',
+      );
+      setDownloadPrescriptionKeys([]); // reset download
+    }
+  }, [downloadPrescriptionKeys, prescriptionsToDownload.data]);
+
+  useEffect(() => {
+    // download only when both sequencingsToDownload and something to download
+    if (downloadSequencingKeys.length > 0 && sequencingsToDownload.data.length > 0) {
+      downloadAsTSV(
+        sequencingsToDownload.data,
+        downloadSequencingKeys,
+        'request_id',
+        sequencingsColumns(),
+        'RQ',
+      );
+      setDownloadSequencingKeys([]); // reset download
+    }
+  }, [downloadSequencingKeys, sequencingsToDownload.data]);
+
   const searchPrescription = (value: any) => {
     if (value.target.value) {
       setSearchValue(value.target.value);
@@ -142,6 +205,9 @@ const PrescriptionSearch = (): React.ReactElement => {
                 results={prescriptions}
                 queryConfig={prescriptionQueryConfig}
                 setQueryConfig={setPrescriptionQueryConfig}
+                setDownloadKeys={(keys) => {
+                  setDownloadPrescriptionKeys(keys);
+                }}
                 loading={prescriptions.loading}
               />
             </Tabs.TabPane>
@@ -159,6 +225,9 @@ const PrescriptionSearch = (): React.ReactElement => {
                 results={sequencings}
                 queryConfig={sequencingQueryConfig}
                 setQueryConfig={setSequencingQueryConfig}
+                setDownloadKeys={(keys) => {
+                  setDownloadSequencingKeys(keys);
+                }}
                 loading={sequencings.loading}
               />
             </Tabs.TabPane>

--- a/src/views/Prescriptions/utils/export.ts
+++ b/src/views/Prescriptions/utils/export.ts
@@ -1,28 +1,52 @@
 import get from 'lodash/get';
 
+import { downloadText } from 'utils/helper';
+
+export const ALL_KEYS = '*';
+
 export const exportAsTSV = (data: any[], headers: string[]): string => {
   let tsv = '';
-  if (data && headers && data.length > 0 && headers.length > 0) {
+  if (data && headers && headers.length > 0) {
     tsv += headers.join('\t');
     tsv += '\n';
     data.forEach((row) => {
+      const values: string[] = [];
       headers.forEach((header) => {
-        tsv += String(get(row, header, '')) + '\t';
+        values.push(String(get(row, header, '')));
       });
+      tsv += values.join('\t');
       tsv += '\n';
     });
   }
   return tsv;
 };
 
+export const downloadAsTSV = (
+  data: any[],
+  dataKeys: string[],
+  key: string,
+  columns: any[],
+  prefix: string,
+) => {
+  const filtered = extractSelectionFromResults(data, dataKeys, key);
+  const headers = columns.map((c) => c.key);
+  const tsv = exportAsTSV(filtered, headers);
+  downloadText(tsv, `${prefix}_${makeFilenameDatePart()}.tsv`, 'text/csv');
+};
+
 export const extractSelectionFromResults = (
   data: any[],
-  selectedKeys: string[],
+  dataKeys: string[],
   key: string,
-): any[] =>
-  selectedKeys?.length > 0 // if no selection then download all
-    ? data.filter((row) => selectedKeys.includes(row[key]))
-    : data;
+): any[] => {
+  if (dataKeys.length === 0) {
+    return [];
+  } else if (dataKeys.length === 1 && dataKeys[0] === ALL_KEYS) {
+    return data;
+  } else {
+    return data.filter((row) => dataKeys.includes(row[key]));
+  }
+};
 
 const joinWithPadding = (l: number[]) => l.reduce((xs, x) => xs + `${x}`.padStart(2, '0'), '');
 

--- a/src/views/Prescriptions/utils/tests/export.test.js
+++ b/src/views/Prescriptions/utils/tests/export.test.js
@@ -6,7 +6,10 @@ describe('exportAsTSV', () => {
     expect(exportAsTSV([{ foo: 'bar' }], null)).toEqual('');
   });
   test('should export data', () => {
-    expect(exportAsTSV([{ foo: 'bar' }], ['foo'])).toEqual('foo\nbar\t\n');
+    expect(exportAsTSV([{ foo: 'bar' }], ['foo'])).toEqual('foo\nbar\n');
+  });
+  test('should export at least headers', () => {
+    expect(exportAsTSV([], ['foo'])).toEqual('foo\n');
   });
 });
 
@@ -22,6 +25,18 @@ describe('extractSelectionFromResults', () => {
     const data = [{ foo: 'bar' }, { field: 'bar' }];
     const selection = ['bar'];
     const expected = [{ field: 'bar' }];
+    expect(extractSelectionFromResults(data, selection, 'field')).toEqual(expected);
+  });
+  test('should return all', () => {
+    const data = [{ foo: 'bar' }, { field: 'bar' }];
+    const selection = ['*'];
+    const expected = [{ foo: 'bar' }, { field: 'bar' }];
+    expect(extractSelectionFromResults(data, selection, 'field')).toEqual(expected);
+  });
+  test('should return nothing', () => {
+    const data = [{ foo: 'bar' }, { field: 'bar' }];
+    const selection = [];
+    const expected = [];
     expect(extractSelectionFromResults(data, selection, 'field')).toEqual(expected);
   });
 });


### PR DESCRIPTION
**New implementation of export as TSV feature**

This implementation allows to download even what's not displayed in the current page when user select **all** rows.

From a performance point of view, the requests to list the elements to download are always done but the limit size is 0 if nothing selected (good workaround to my opinion).

![Screenshot from 2022-11-23 12-37-20](https://user-images.githubusercontent.com/35352649/203612971-bb546133-9331-4f3f-b047-2089fcbbbde8.png)
