### PR TITLE
fix: CLIN-1692 largeur acceuil

### DIFF
--- a/src/views/Home/index.module.scss
+++ b/src/views/Home/index.module.scss
@@ -9,6 +9,8 @@
 
     .contentCardWrapper {
       height: 100%;
+      max-width: 1200px;
+      margin: auto;
 
       .contentCard {
         &:global(.ant-card) {


### PR DESCRIPTION
ajouter max-width a la page d'acceuil

avant:
![image](https://user-images.githubusercontent.com/52966302/219105958-5138b9d6-8f30-4778-8635-66c39b517906.png)
Après:
![image](https://user-images.githubusercontent.com/52966302/219106050-eedbbd2d-5c65-4198-a841-4c38c29c0e7b.png)
