### PR TITLE
fix: CLIN-1811 tag specific famille

### DIFF
--- a/src/components/uiKit/PositionTag/index.tsx
+++ b/src/components/uiKit/PositionTag/index.tsx
@@ -2,12 +2,12 @@ import intl from 'react-intl-universal';
 import { Tag } from 'antd';
 
 interface OwnProps {
-  isParent: boolean | undefined;
+  familyCode: string | undefined;
 }
 
-const PositionTag = ({ isParent }: OwnProps) =>
-  isParent ? (
-    <Tag color="geekblue">{intl.get('parent')}</Tag>
+const PositionTag = ({ familyCode }: OwnProps) =>
+  familyCode ? (
+    <Tag color="geekblue">{intl.get(familyCode)}</Tag>
   ) : (
     <Tag color="red">{intl.get('proband')}</Tag>
   );

--- a/src/graphql/prescriptions/helper.tsx
+++ b/src/graphql/prescriptions/helper.tsx
@@ -2,12 +2,14 @@ import { ServiceRequestEntity } from 'api/fhir/models';
 
 import PositionTag from 'components/uiKit/PositionTag';
 
-const isParent = (prescription: ServiceRequestEntity | undefined, patientid: string) =>
-  prescription?.extensions?.some(function (o) {
+const getFamilyCode = (prescription: ServiceRequestEntity | undefined, patientid: string) => {
+  const familyReference = prescription?.extensions?.find(function (o) {
     return o.extension?.[1].valueReference?.reference.includes(patientid);
   });
+  return familyReference?.extension?.[0].valueCoding?.coding?.[0].code;
+};
 
 export const getPositionTag = (
   prescription: ServiceRequestEntity | undefined,
   patientid: string,
-) => <PositionTag key="type-tag" isParent={isParent(prescription, patientid)} />;
+) => <PositionTag key="type-tag" familyCode={getFamilyCode(prescription, patientid)} />;


### PR DESCRIPTION
Changer le tag parent pour le tag correspondant au membre de la famille dans page variant

Avant
![image](https://user-images.githubusercontent.com/52966302/228325255-5ee260f3-dc2e-458f-9546-69518d89b834.png)

Après
![image](https://user-images.githubusercontent.com/52966302/228325042-ef02711e-624c-4dab-9a29-4005b3ceaa74.png)
![image](https://user-images.githubusercontent.com/52966302/228325130-ffc613b9-190d-4703-ae1a-80c7e55ae0ef.png)
