### PR TITLE
fix: CLIN-1845 - ignore cache for codes request

### DIFF
--- a/src/api/fhir/index.ts
+++ b/src/api/fhir/index.ts
@@ -80,6 +80,9 @@ const fetchServiceRequestCodes = () =>
   sendRequestWithRpt<ServiceRequestCode>({
     method: 'GET',
     url: `${FHIR_API_URL}/CodeSystem/analysis-request-code`,
+    headers: {
+      'Cache-Control': 'no-cache',
+    },
   });
 
 const getFileURL = async (fileUrl: string) =>


### PR DESCRIPTION
- [x] This GET request has no param and response shouldn't be from browser cache when we do a release