### PR TITLE
fix: CLIN-2019 activated sort on exomiser score column

### DIFF
--- a/release-ticket
+++ b/release-ticket
@@ -1,1 +1,1 @@
-[Dictionnaire] Ajouter des valeurs aux facettes Transmission
+[Prod] Le tri sur le score Exomiser ne fonctionne pas

--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -343,6 +343,9 @@ export const getVariantColumns = (
         title: intl.get('screen.patientsnv.results.table.acmg_classification'),
         tooltip: intl.get('screen.patientsnv.results.table.acmg_classification.tooltip'),
         width: 110,
+        sorter: {
+          multiple: 1,
+        },
         render: (record: VariantEntity) =>
           renderDonorByKey(
             'donors.exomiser.acmg_classification',

--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -329,6 +329,9 @@ export const getVariantColumns = (
         title: intl.get('screen.patientsnv.results.table.gene_combined_score'),
         tooltip: intl.get('screen.patientsnv.results.table.gene_combined_score.tooltip'),
         width: 59,
+        sorter: {
+          multiple: 1,
+        },
         render: (record: VariantEntity) =>
           renderDonorByKey(
             'donors.exomiser.gene_combined_score',

--- a/src/views/Snv/utils/constant.ts
+++ b/src/views/Snv/utils/constant.ts
@@ -18,6 +18,7 @@ export const DEFAULT_PAGING_CONFIG = {
 };
 
 export const DEFAULT_SORT_QUERY = [
+  { field: 'donors.exomiser.gene_combined_score', order: SortDirection.Desc },
   { field: 'max_impact_score', order: SortDirection.Desc },
   { field: 'hgvsg', order: SortDirection.Asc },
 ] as ISort[];


### PR DESCRIPTION
# FIX : [Prod] Le tri sur le score Exomiser ne fonctionne pas

- closes #CLIN-2019

## Description
Exomiser score column is now sortable

[JIRA LINK]https://ferlab-crsj.atlassian.net/browse/CLIN-2019

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
