### PR TITLE
Cypress/clin 2051 clin 2015 clin 1952 cypress

### DIFF
--- a/cypress/e2e/Colonnes/TableauVariantsPatient.cy.ts
+++ b/cypress/e2e/Colonnes/TableauVariantsPatient.cy.ts
@@ -55,29 +55,29 @@ describe('Page des variants d\'un patient - Colonnes du tableau', () => {
       .contains('ClinVar').should('exist');
 
     cy.get('thead[class="ant-table-thead"]')
-      .find('th[class*="ant-table-cell"]').eq(9)
-      .should('not.have.class', 'ant-table-column-has-sorters')
-      .contains('ACMG').should('exist');
+    .find('th[class*="ant-table-cell"]').eq(9)
+    .should('have.class', 'ant-table-column-has-sorters')
+    .contains('Exo.').should('exist');
 
     cy.get('thead[class="ant-table-thead"]')
       .find('th[class*="ant-table-cell"]').eq(10)
       .should('have.class', 'ant-table-column-has-sorters')
-      .contains('gnomAD').should('exist');
+      .contains('ACMG Exo.').should('exist');
 
     cy.get('thead[class="ant-table-thead"]')
       .find('th[class*="ant-table-cell"]').eq(11)
-      .should('have.class', 'ant-table-column-has-sorters')
-      .contains('RQDM').should('exist');
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('ACMG').should('exist');
 
     cy.get('thead[class="ant-table-thead"]')
       .find('th[class*="ant-table-cell"]').eq(12)
       .should('have.class', 'ant-table-column-has-sorters')
-      .contains('Exo.').should('exist');
+      .contains('gnomAD').should('exist');
 
     cy.get('thead[class="ant-table-thead"]')
       .find('th[class*="ant-table-cell"]').eq(13)
       .should('have.class', 'ant-table-column-has-sorters')
-      .contains('ACMG Exo.').should('exist');
+      .contains('RQDM').should('exist');
 
     cy.get('thead[class="ant-table-thead"]')
       .find('th[class*="ant-table-cell"]').eq(14)

--- a/cypress/e2e/Consultation/PageVariantResume.cy.ts
+++ b/cypress/e2e/Consultation/PageVariantResume.cy.ts
@@ -67,7 +67,7 @@ describe('Page d\'un variant (onglet Résumé) - Vérifier les informations affi
     cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(4).contains('36').should('exist');
     cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(4).contains('Voir plus').should('exist');
     cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(4).contains('Dann').should('not.exist');
-    cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(5).contains('0.4025').should('exist');
+    cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(5).contains('0.599').should('exist');
     cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(6).contains('ENST00000401061').should('exist');
     cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(6).find('svg[class*="canonicalIcon"]').should('exist');
     cy.get('[data-row-key="Consequences_MMACHC_1"]').find('td[class*="ant-table-cell"]').eq(7).contains('NM_015506.3').should('exist');

--- a/cypress/e2e/Navigation/Pages.cy.ts
+++ b/cypress/e2e/Navigation/Pages.cy.ts
@@ -262,7 +262,7 @@ describe('Affichage de toutes les pages et modals', () => {
     cy.contains('ADN codant').should('exist', {timeout: 20*1000});
     cy.contains('VEP').should('exist', {timeout: 20*1000});
     cy.contains('Prédiction').should('exist', {timeout: 20*1000});
-    cy.contains('Conservation (PhyloP17Way)').should('exist', {timeout: 20*1000});
+    cy.contains('Conservation').should('exist', {timeout: 20*1000});
     cy.contains('Ensembl ID').should('exist', {timeout: 20*1000});
     cy.contains('RefSeq ID').should('exist', {timeout: 20*1000});
     cy.contains('Critères ACMG').should('exist', {timeout: 20*1000});


### PR DESCRIPTION
# FEAT : Adjust Cypress tests

- complements #CLIN-2051 #CLIN-2015 #CLIN-1952

## Description

[CLIN-2051](https://ferlab-crsj.atlassian.net/browse/CLIN-2051) [Scores] ETL: utiliser colonne phyloP17way_primate
[CLIN-2015](https://ferlab-crsj.atlassian.net/browse/CLIN-2015) [Variants] Ajuster l'ordre des colonnes d'Exomiser
[CLIN-1952](https://ferlab-crsj.atlassian.net/browse/CLIN-1952) [Scores] Frontend : Changements et ajouts