### PR TITLE
fix: CLIN-2031 number 1 and 0 correctly display in filters

### DIFF
--- a/release-ticket
+++ b/release-ticket
@@ -1,1 +1,1 @@
-Mettre a jour ferlab-ui pour les query nested
+[fix] Fix number in checkbox list filters

--- a/src/graphql/utils/tests/filters.spec.ts
+++ b/src/graphql/utils/tests/filters.spec.ts
@@ -1,0 +1,29 @@
+import * as formattingMod from '@ferlab/ui/core/data/arranger/formatting';
+
+import { keyEnhanceBooleanOnlyExcept } from '../Filters';
+
+describe('Filters', () => {
+  describe('keyEnhanceBooleanOnlyExcept', () => {
+    test('Should only set True or False for boolean content', () => {
+      expect(keyEnhanceBooleanOnlyExcept('', 'true', 'boolean')).toEqual('True');
+      expect(keyEnhanceBooleanOnlyExcept('', 'false', 'boolean')).toEqual('False');
+    });
+
+    test('Should not interpret 0 or 1 value as boolean', () => {
+      expect(keyEnhanceBooleanOnlyExcept('', '1')).toEqual('1');
+      expect(keyEnhanceBooleanOnlyExcept('', '0')).toEqual('0');
+    });
+
+    test('should not call keyEnhance when field is chromosome', () => {
+      const spy = jest.spyOn(formattingMod, 'keyEnhance').mockReturnValue('1');
+      expect(keyEnhanceBooleanOnlyExcept('chromosome', '1')).toEqual('1');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('should call keyEnhance when field anything but chromosome', () => {
+      const spy = jest.spyOn(formattingMod, 'keyEnhance').mockReturnValue('1');
+      expect(keyEnhanceBooleanOnlyExcept('somethingelse', '1')).toEqual('1');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# FIX : 

- closes #CLIN-2031

## Description

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2031)

Acceptance Criterias
- 1 et 0 sont afficher comme des numéro
- true et false demeure true et false

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![Screenshot 2023-07-13 at 11 50 36 AM](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/98903/7e9429df-c87a-434a-b950-892115dab4a8)

### After
![Screenshot 2023-07-17 at 1 49 37 PM](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/98903/375399d7-8482-4e8d-97b6-30121f43ba0d)


## QA
voir les filtres sous 'Variant'

## Mention

@kstonge @luclemo
