### PR TITLE
fix: CLIN-1923 placeholder case vide

### DIFF
--- a/release-ticket
+++ b/release-ticket
@@ -1,1 +1,1 @@
-[Assignation] ajout feature assignation
+[fix] Ajouter un tiret aux cases vides

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -27,6 +27,7 @@ export const enum MIME_TYPES {
 export const FILTER_ID_QUERY_PARAM_KEY = 'filterId';
 export const SHARED_FILTER_ID_QUERY_PARAM_KEY = 'sharedFilterId';
 export const TABLE_EMPTY_PLACE_HOLDER = '-';
+export const TSV_EMPTY_PLACE_HOLDER = '--';
 export const MAIN_SCROLL_WRAPPER_ID = 'main-scroll-wrapper';
 
 export const SERVICE_REQUEST_CODE_MAP_KEY = 'fhir_service_request_codes';

--- a/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
+++ b/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
@@ -12,7 +12,6 @@ import { TABLE_EMPTY_PLACE_HOLDER } from 'utils/constants';
 import { formatDate } from 'utils/date';
 import EnvironmentVariables from 'utils/EnvVariables';
 
-<<<<<<< HEAD
 import { AssignmentsFilterDropdown } from './components/AssignmentFilter';
 import AssignmentsCell from './components/AssignmentsCell';
 export const prescriptionsColumns = (
@@ -87,7 +86,7 @@ export const prescriptionsColumns = (
       dataIndex: ['requester'],
       title: intl.get('screen.patientsearch.table.requester'),
       tooltip: intl.get('screen.patientsearch.table.requester.tooltip'),
-      render: (requester: string) => requester ?? TABLE_EMPTY_PLACE_HOLDER,
+      render: (requester: string) => requester || TABLE_EMPTY_PLACE_HOLDER,
       sorter: { multiple: 1 },
       defaultHidden: true,
     },
@@ -131,96 +130,3 @@ export const prescriptionsColumns = (
 
   return columns;
 };
-=======
-export const prescriptionsColumns = (): ProColumnType<ITableAnalysisResult>[] => [
-  {
-    key: 'prescription_id',
-    dataIndex: ['prescription_id'],
-    render: (prescription_id: string) => (
-      <Link to={`/prescription/entity/${prescription_id}`}>{prescription_id}</Link>
-    ),
-    title: intl.get('screen.patientsearch.table.prescription'),
-    sorter: { multiple: 1 },
-  },
-  {
-    key: 'patient_id',
-    dataIndex: ['patient_id'],
-    render: (patient_id: string) => patient_id,
-    title: intl.get('screen.patientsearch.table.patient'),
-    sorter: { multiple: 1 },
-  },
-  {
-    key: 'status',
-    dataIndex: 'status',
-    render: (value: string) =>
-      value ? <StatusTag dictionary={getPrescriptionStatusDictionnary()} status={value} /> : null,
-    title: intl.get('screen.patientsearch.table.status'),
-    sorter: { multiple: 1 },
-  },
-  {
-    key: 'created_on',
-    dataIndex: 'created_on',
-    render: (date: string) => formatDate(date),
-    title: intl.get('screen.patientsearch.table.createdOn'),
-    tooltip: intl.get('screen.patientsearch.table.createdOn.tooltip'),
-    sorter: { multiple: 1 },
-  },
-  {
-    key: 'timestamp',
-    dataIndex: 'timestamp',
-    render: (date: string) => formatDate(date),
-    title: intl.get('screen.patientsearch.table.updatedOn'),
-    tooltip: intl.get('screen.patientsearch.table.updatedOn.tooltip'),
-    sorter: { multiple: 1 },
-    defaultHidden: true,
-  },
-  {
-    key: 'analysis_code',
-    dataIndex: ['analysis_code'],
-    title: intl.get('screen.patientsearch.table.test'),
-    tooltip: intl.get('screen.patientsearch.table.test.tooltip'),
-    sorter: { multiple: 1 },
-  },
-  {
-    key: 'ldm',
-    dataIndex: ['ldm'],
-    render: (labo: string) => extractOrganizationId(labo),
-    title: intl.get('screen.patientsearch.table.ldm'),
-    tooltip: intl.get('screen.patientsearch.table.ldm.tooltip'),
-    sorter: { multiple: 1 },
-  },
-  {
-    key: 'ep',
-    dataIndex: ['ep'],
-    title: intl.get('screen.patientsearch.table.ep'),
-    tooltip: intl.get('screen.patientsearch.table.ep.tooltip'),
-    sorter: { multiple: 1 },
-  },
-  {
-    key: 'requester',
-    dataIndex: ['requester'],
-    title: intl.get('screen.patientsearch.table.requester'),
-    tooltip: intl.get('screen.patientsearch.table.requester.tooltip'),
-    render: (requester: string) => requester || TABLE_EMPTY_PLACE_HOLDER,
-    sorter: { multiple: 1 },
-    defaultHidden: true,
-  },
-  {
-    key: 'prenatal',
-    dataIndex: ['prenatal'],
-    title: intl.get('screen.patientsearch.table.prenatal'),
-    tooltip: intl.get('screen.patientsearch.table.prenatal.tooltip'),
-    sorter: { multiple: 1 },
-    render: (prenatal: boolean) => intl.get(prenatal ? 'yes' : 'no'),
-    defaultHidden: true,
-  },
-  {
-    key: 'patient_mrn',
-    dataIndex: 'patient_mrn',
-    title: intl.get('screen.patientsearch.table.mrn'),
-    tooltip: intl.get('screen.patientsearch.table.mrn.tooltip'),
-    sorter: { multiple: 1 },
-    defaultHidden: true,
-  },
-];
->>>>>>> c15ad84... fix: CLIN-1923 placeholder case vide

--- a/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
+++ b/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
@@ -201,7 +201,7 @@ export const prescriptionsColumns = (): ProColumnType<ITableAnalysisResult>[] =>
     dataIndex: ['requester'],
     title: intl.get('screen.patientsearch.table.requester'),
     tooltip: intl.get('screen.patientsearch.table.requester.tooltip'),
-    render: (requester: string) => (requester ? requester : TABLE_EMPTY_PLACE_HOLDER),
+    render: (requester: string) => requester || TABLE_EMPTY_PLACE_HOLDER,
     sorter: { multiple: 1 },
     defaultHidden: true,
   },

--- a/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
+++ b/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
@@ -12,6 +12,7 @@ import { TABLE_EMPTY_PLACE_HOLDER } from 'utils/constants';
 import { formatDate } from 'utils/date';
 import EnvironmentVariables from 'utils/EnvVariables';
 
+<<<<<<< HEAD
 import { AssignmentsFilterDropdown } from './components/AssignmentFilter';
 import AssignmentsCell from './components/AssignmentsCell';
 export const prescriptionsColumns = (
@@ -130,3 +131,96 @@ export const prescriptionsColumns = (
 
   return columns;
 };
+=======
+export const prescriptionsColumns = (): ProColumnType<ITableAnalysisResult>[] => [
+  {
+    key: 'prescription_id',
+    dataIndex: ['prescription_id'],
+    render: (prescription_id: string) => (
+      <Link to={`/prescription/entity/${prescription_id}`}>{prescription_id}</Link>
+    ),
+    title: intl.get('screen.patientsearch.table.prescription'),
+    sorter: { multiple: 1 },
+  },
+  {
+    key: 'patient_id',
+    dataIndex: ['patient_id'],
+    render: (patient_id: string) => patient_id,
+    title: intl.get('screen.patientsearch.table.patient'),
+    sorter: { multiple: 1 },
+  },
+  {
+    key: 'status',
+    dataIndex: 'status',
+    render: (value: string) =>
+      value ? <StatusTag dictionary={getPrescriptionStatusDictionnary()} status={value} /> : null,
+    title: intl.get('screen.patientsearch.table.status'),
+    sorter: { multiple: 1 },
+  },
+  {
+    key: 'created_on',
+    dataIndex: 'created_on',
+    render: (date: string) => formatDate(date),
+    title: intl.get('screen.patientsearch.table.createdOn'),
+    tooltip: intl.get('screen.patientsearch.table.createdOn.tooltip'),
+    sorter: { multiple: 1 },
+  },
+  {
+    key: 'timestamp',
+    dataIndex: 'timestamp',
+    render: (date: string) => formatDate(date),
+    title: intl.get('screen.patientsearch.table.updatedOn'),
+    tooltip: intl.get('screen.patientsearch.table.updatedOn.tooltip'),
+    sorter: { multiple: 1 },
+    defaultHidden: true,
+  },
+  {
+    key: 'analysis_code',
+    dataIndex: ['analysis_code'],
+    title: intl.get('screen.patientsearch.table.test'),
+    tooltip: intl.get('screen.patientsearch.table.test.tooltip'),
+    sorter: { multiple: 1 },
+  },
+  {
+    key: 'ldm',
+    dataIndex: ['ldm'],
+    render: (labo: string) => extractOrganizationId(labo),
+    title: intl.get('screen.patientsearch.table.ldm'),
+    tooltip: intl.get('screen.patientsearch.table.ldm.tooltip'),
+    sorter: { multiple: 1 },
+  },
+  {
+    key: 'ep',
+    dataIndex: ['ep'],
+    title: intl.get('screen.patientsearch.table.ep'),
+    tooltip: intl.get('screen.patientsearch.table.ep.tooltip'),
+    sorter: { multiple: 1 },
+  },
+  {
+    key: 'requester',
+    dataIndex: ['requester'],
+    title: intl.get('screen.patientsearch.table.requester'),
+    tooltip: intl.get('screen.patientsearch.table.requester.tooltip'),
+    render: (requester: string) => (requester ? requester : TABLE_EMPTY_PLACE_HOLDER),
+    sorter: { multiple: 1 },
+    defaultHidden: true,
+  },
+  {
+    key: 'prenatal',
+    dataIndex: ['prenatal'],
+    title: intl.get('screen.patientsearch.table.prenatal'),
+    tooltip: intl.get('screen.patientsearch.table.prenatal.tooltip'),
+    sorter: { multiple: 1 },
+    render: (prenatal: boolean) => intl.get(prenatal ? 'yes' : 'no'),
+    defaultHidden: true,
+  },
+  {
+    key: 'patient_mrn',
+    dataIndex: 'patient_mrn',
+    title: intl.get('screen.patientsearch.table.mrn'),
+    tooltip: intl.get('screen.patientsearch.table.mrn.tooltip'),
+    sorter: { multiple: 1 },
+    defaultHidden: true,
+  },
+];
+>>>>>>> c15ad84... fix: CLIN-1923 placeholder case vide

--- a/src/views/Prescriptions/Search/components/table/SequencingTable/columns.tsx
+++ b/src/views/Prescriptions/Search/components/table/SequencingTable/columns.tsx
@@ -20,8 +20,7 @@ export const sequencingsColumns = (): ProColumnType<ITableSequencingResult>[] =>
   },
   {
     key: 'sample',
-    render: (results: SequencingResult) =>
-      results?.sample ? results.sample : TABLE_EMPTY_PLACE_HOLDER,
+    render: (results: SequencingResult) => results?.sample || TABLE_EMPTY_PLACE_HOLDER,
     title: intl.get('screen.sequencingsearch.table.sample'),
     tooltip: intl.get('screen.sequencingsearch.table.sample.tooltip'),
     sorter: { multiple: 1 },
@@ -94,7 +93,7 @@ export const sequencingsColumns = (): ProColumnType<ITableSequencingResult>[] =>
     dataIndex: ['requester'],
     title: intl.get('screen.patientsearch.table.requester'),
     tooltip: intl.get('screen.patientsearch.table.requester.tooltip'),
-    render: (requester: string) => (requester ? requester : TABLE_EMPTY_PLACE_HOLDER),
+    render: (requester: string) => requester || TABLE_EMPTY_PLACE_HOLDER,
     sorter: { multiple: 1 },
     defaultHidden: true,
   },

--- a/src/views/Prescriptions/Search/components/table/SequencingTable/columns.tsx
+++ b/src/views/Prescriptions/Search/components/table/SequencingTable/columns.tsx
@@ -20,7 +20,8 @@ export const sequencingsColumns = (): ProColumnType<ITableSequencingResult>[] =>
   },
   {
     key: 'sample',
-    render: (results: SequencingResult) => results.sample,
+    render: (results: SequencingResult) =>
+      results?.sample ? results.sample : TABLE_EMPTY_PLACE_HOLDER,
     title: intl.get('screen.sequencingsearch.table.sample'),
     tooltip: intl.get('screen.sequencingsearch.table.sample.tooltip'),
     sorter: { multiple: 1 },
@@ -93,7 +94,7 @@ export const sequencingsColumns = (): ProColumnType<ITableSequencingResult>[] =>
     dataIndex: ['requester'],
     title: intl.get('screen.patientsearch.table.requester'),
     tooltip: intl.get('screen.patientsearch.table.requester.tooltip'),
-    render: (requester: string) => requester ?? TABLE_EMPTY_PLACE_HOLDER,
+    render: (requester: string) => (requester ? requester : TABLE_EMPTY_PLACE_HOLDER),
     sorter: { multiple: 1 },
     defaultHidden: true,
   },

--- a/src/views/Prescriptions/utils/export.ts
+++ b/src/views/Prescriptions/utils/export.ts
@@ -16,6 +16,7 @@ import {
   renderOmimToString,
 } from 'views/Snv/Exploration/variantColumns';
 
+import { TABLE_EMPTY_PLACE_HOLDER, TSV_EMPTY_PLACE_HOLDER } from 'utils/constants';
 import { downloadText } from 'utils/helper';
 
 export const ALL_KEYS = '*';
@@ -33,7 +34,7 @@ const valueToStr = (value: any): string => {
     }
     return String(value);
   }
-  return '';
+  return TSV_EMPTY_PLACE_HOLDER;
 };
 
 function getLeafNodes(obj: any): string {
@@ -123,7 +124,12 @@ const addPatientIdContent = (sqon: ISyntheticSqon, patientId?: string): ISynthet
   return sqon;
 };
 
-export const convertToPlain = (html: string) => html.replace(/<[^>]+>/g, '');
+export const convertToPlain = (html: string) => {
+  if (html === TABLE_EMPTY_PLACE_HOLDER) {
+    return TSV_EMPTY_PLACE_HOLDER;
+  }
+  return html.replace(/<[^>]+>/g, '');
+};
 
 export const customMapping = (prefix: string, key: string, row: any, patientId: string = '') => {
   if (prefix === 'SNV') {
@@ -136,7 +142,7 @@ export const customMapping = (prefix: string, key: string, row: any, patientId: 
     } else if (key === 'omim') {
       return convertToPlain(renderOmimToString(row));
     } else if (key === 'acmgcriteria') {
-      return getAcmgRuleContent(row.varsome);
+      return convertToPlain(getAcmgRuleContent(row.varsome));
     } else if (key === 'consequence') {
       return convertToPlain(renderConsequencesToString(row));
     } else if (

--- a/src/views/Prescriptions/utils/tests/export.test.js
+++ b/src/views/Prescriptions/utils/tests/export.test.js
@@ -177,7 +177,7 @@ describe('customMapping SNV', () => {
     expect(customMapping('SNV', 'donors.exomiser.acmg_classification', row, 'p1')).toEqual(
       'Foo Bar',
     );
-    expect(customMapping('SNV', 'donors.exomiser.acmg_evidence', row, 'p1')).toEqual('-');
+    expect(customMapping('SNV', 'donors.exomiser.acmg_evidence', row, 'p1')).toEqual('--');
   });
   test('should map donors.gq', () => {
     const row = {

--- a/src/views/Snv/components/OccurrenceDrawer/HcDescription/index.tsx
+++ b/src/views/Snv/components/OccurrenceDrawer/HcDescription/index.tsx
@@ -52,7 +52,7 @@ export const HcComplementDescription = ({
   const nodes = extractHits<Complements>(hcComplements?.hits);
   const nOfSymbols = nodes?.length ?? 0;
   if (!nodes || nOfSymbols === 0) {
-    return <Text>{defaultText}</Text>;
+    return <>{defaultText}</>;
   }
 
   return (


### PR DESCRIPTION
# FIX: Ajouter un tiret aux cases vides

- closes #CLIN-1923

## Description
Afficher un tiret au lieu d’une case vide dans tous les tableaux.Pour les exports tsv, afficher 2 tirets

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-1923)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/cb213487-ddec-4171-b537-75a6df7a90ad)
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/7e2cc04e-a69d-4faf-9430-04009baf4b40)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/742a6f66-4d81-4412-8736-f9b3a3633e87)
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/fcb2c8ac-96c8-4178-8edb-1ac9b356bc09)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
