### PR TITLE
feat: CLIN-2082 nouvelle query colonne gene

### DIFF
--- a/release-ticket
+++ b/release-ticket
@@ -1,1 +1,1 @@
-[TableauSNV] Le filtre de QG > X (un nombre entier) + No Data ne retourne des valeur numériques < X
+[SNV] Le + dans la colonne Gène doit créer une nouvelle Query

--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -5,8 +5,8 @@ import { Link } from 'react-router-dom';
 import { PlusOutlined } from '@ant-design/icons';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
-import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
-import { MERGE_VALUES_STRATEGIES } from '@ferlab/ui/core/data/sqon/types';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
 import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
 import { Button, Space, Tag, Tooltip, Typography } from 'antd';
@@ -279,12 +279,18 @@ export const getVariantColumns = (
               <div
                 className={style.addGeneButton}
                 onClick={() => {
-                  updateActiveQueryField({
+                  addQuery({
                     queryBuilderId,
-                    field: 'consequences.symbol',
-                    value: [geneSymbol],
-                    index: INDEXES.VARIANT,
-                    merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,
+                    query: generateQuery({
+                      newFilters: [
+                        generateValueFilter({
+                          field: 'consequences.symbol',
+                          value: [geneSymbol],
+                          index: INDEXES.VARIANT,
+                        }),
+                      ],
+                    }),
+                    setAsActive: true,
                   });
                 }}
               >

--- a/src/views/Snv/utils/tests/helper.spec.js
+++ b/src/views/Snv/utils/tests/helper.spec.js
@@ -231,7 +231,6 @@ describe('wrapSqonWithDonorIdAndSrId', () => {
         },
       ],
       op: 'and',
-      pivot: 'donors',
     };
     expect(wrapSqonWithDonorIdAndSrId(initialSqon, 'foo', null)).toEqual(expected);
   });
@@ -360,7 +359,6 @@ describe('wrapSqonWithDonorIdAndSrId', () => {
         },
       ],
       op: 'and',
-      pivot: 'donors',
     };
     expect(wrapSqonWithDonorIdAndSrId(initialSqon, 'foo', null)).toEqual(expected);
   });
@@ -513,7 +511,6 @@ describe('wrapSqonWithDonorIdAndSrId', () => {
         },
       ],
       op: 'or',
-      pivot: 'donors',
     };
 
     expect(wrapSqonWithDonorIdAndSrId(initialSqon, 'foo', null)).toEqual(expected);


### PR DESCRIPTION
# FEAT : Le + dans la colonne Gène doit créer une nouvelle Query

- closes #CLIN-2082

## Description
En ce moment cliquer sur le + ajoute le symbole dans la query active. il faut changer ce comportement pour ajouter le symbol dans une nouvelle barre de Query. 
[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2082)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/b5935d10-e999-4453-8174-dc45d7e443d1)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/7cf5bc68-e077-4339-8d4f-9f84b9573121)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

