### PR TITLE
fix: CLIN-2114 traduire nodata tableau

### DIFF
--- a/release-ticket
+++ b/release-ticket
@@ -1,1 +1,1 @@
-[Variants] Ne pas afficher Null quand il n'y a pas de changement d'acide aminé
+[Tableaux] Traduire No available data

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -73,6 +73,9 @@ export const getProTableDictionary = (): IProTableDictionary => ({
     next: intl.get('next'),
     view: intl.get('view'),
   },
+  table: {
+    emptyText: intl.get('no.results.found'),
+  },
 });
 
 export const getAssignmentDictionary = (): IAssignmentsDictionary => ({


### PR DESCRIPTION
# FIX : Traduire "No available data"

- closes #CLIN-2114

## Description
Dans tous les tableaux, traduire “No available data” par “Aucun résultat”

[[JIRA LINK]
](https://ferlab-crsj.atlassian.net/browse/CLIN-2114)
Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/d2e2bb36-0ea8-44fa-934a-28075f8a0aaf)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/9a35912e-a80b-462a-8f6e-f6169f5546aa)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

