### PR TITLE
feat: CLIN-1870 ajout locus requete hc

### DIFF
--- a/cypress/e2e/Consultation/TiroirOccurrence.cy.ts
+++ b/cypress/e2e/Consultation/TiroirOccurrence.cy.ts
@@ -44,7 +44,7 @@ describe('Tiroir d\'une occurrence', () => {
     cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(1).find('tr[class="ant-descriptions-row"]').eq(1).contains('3').click({force: true});
     cy.wait('@getPOSTgraphql1', {timeout: 20*1000});
     cy.wait('@getPOSTgraphql1', {timeout: 20*1000});
-    cy.contains('3 Résultats').should('exist', {timeout: 60*1000});
+    cy.contains('4 Résultats').should('exist', {timeout: 60*1000});
 
     cy.intercept('POST', '**/graphql').as('getPOSTgraphql2');
     cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(1).find('tr[class="ant-descriptions-row"]').eq(2).contains('4').click({force: true});

--- a/release-ticket
+++ b/release-ticket
@@ -1,1 +1,1 @@
-[Dictionnaire] Ajouter des valeurs aux références externes.
+[HC] Ajouter le locus du variant du tiroir en question à la requête HC

--- a/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
+++ b/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
@@ -190,6 +190,7 @@ const VariantsTab = ({
           modalOpened={modalOpened}
           variantId={selectedVariant?.hgvsg}
           variantType={variantType}
+          locus={selectedVariant.locus}
         />
       )}
     </>

--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -454,8 +454,18 @@ export const getVariantColumns = (
           tooltip: intl.get('ch.tooltip'),
           defaultHidden: true,
           width: 200,
-          render: (record: VariantEntity) =>
-            renderDonorByKey('ch', findDonorById(record.donors, patientId)),
+          render: (record: VariantEntity) => {
+            const donor = findDonorById(record.donors, patientId);
+            return (
+              <HcComplementDescription
+                hcComplements={donor?.hc_complement}
+                defaultText={TABLE_EMPTY_PLACE_HOLDER}
+                wrap={false}
+                size={0}
+                locus={record.locus}
+              />
+            );
+          },
         },
         {
           key: 'pch',

--- a/src/views/Snv/components/OccurrenceDrawer/HcDescription/index.tsx
+++ b/src/views/Snv/components/OccurrenceDrawer/HcDescription/index.tsx
@@ -19,6 +19,7 @@ type Props = {
   defaultText: string;
   wrap?: boolean;
   size?: number;
+  locus?: string;
 };
 
 type Complements = HcComplement | PossiblyHcComplement;
@@ -46,6 +47,7 @@ const getLocus = (e: HcComplement) => e.locus || [];
 export const HcComplementDescription = ({
   defaultText,
   hcComplements,
+  locus,
   wrap = true,
   size = 8,
 }: Props) => {
@@ -107,7 +109,9 @@ export const HcComplementDescription = ({
                         newFilters: [
                           generateValueFilter({
                             field: 'locus',
-                            value: [...getLocus(e as HcComplement)],
+                            value: locus
+                              ? [...getLocus(e as HcComplement), locus]
+                              : [...getLocus(e as HcComplement)],
                             index: INDEX_VARIANTS,
                           }),
                         ],

--- a/src/views/Snv/components/OccurrenceDrawer/index.tsx
+++ b/src/views/Snv/components/OccurrenceDrawer/index.tsx
@@ -37,6 +37,7 @@ interface OwnProps {
   modalOpened: boolean;
   variantId: string;
   variantType: VariantType;
+  locus: string;
 }
 
 const getParentTitle = (who: 'mother' | 'father', id: string, affected: boolean) => {
@@ -84,6 +85,7 @@ const OccurrenceDrawer = ({
   toggleModal,
   variantId,
   variantType,
+  locus,
 }: OwnProps) => {
   const [modalOpened, setModalVisible] = useState(false);
   return (
@@ -124,6 +126,7 @@ const OccurrenceDrawer = ({
                   <HcComplementDescription
                     hcComplements={donor?.hc_complement}
                     defaultText={TABLE_EMPTY_PLACE_HOLDER}
+                    locus={locus}
                   />
                 </Descriptions.Item>
                 <Descriptions.Item


### PR DESCRIPTION
#FEAT: ajout locus requete hc

- closes #CLIN-1870

## Description
Actuellement, la requête des variants rares ne liste que les locus du variant pour lequel le tiroir est ouvert.

Il faut ajouter le locus de ce dernier à la requête pour avoir tous les HC listés

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-1870)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/03e15d88-d2c5-4b37-bb08-c87b78acd748)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/2a05dc77-0f52-488a-9aa4-08d2ad78bbf3)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

