### PR TITLE
fix: CLIN-2230 [Typo] Les boutons Download devraient être Sentence case

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,7 +38,7 @@
   "compound.heterozygous.abbrev": "{num, plural, =0 {Compound Het.} other {Compound Het.}}",
   "condition": "Condition",
   "deletion": "Deletion",
-  "download.report": "Download Report",
+  "download.report": "Download report",
   "view.ucsc": "View UCSC",
   "view.litvar": "View LitVAR",
   "duplication": "Duplication",


### PR DESCRIPTION
# FIX: [Typo] Les boutons Download devraient être Sentence case

- closes #CLIN-2230

## Description
En anglais: “Download report”

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2230)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/0762f6ed-5aec-446e-8d10-b8828f046cbe)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/b6aa702b-4226-4849-934e-695d234e32a5)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

