### PR TITLE
fix: CLIN-2156 [Query] Formatter la valeur comme dans la facette

### DIFF
--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -238,6 +238,23 @@ export const getQueryBuilderDictionary = (
           not_affected: intl.get('donors.status.not_affected'),
           unknown: intl.get('unknown'),
         },
+        'donors.bioinfo_analysis_code': {
+          TEBA: intl.get('filters.options.donors.bioinfo_analysis_code.TEBA'),
+          TNBA: intl.get('filters.options.donors.bioinfo_analysis_code.TNBA'),
+        },
+        'donors.exomiser.acmg_classification': {
+          PATHOGENIC: intl.get('filters.options.donors.exomiser.acmg_classification.PATHOGENIC'),
+          LIKELY_PATHOGENIC: intl.get(
+            'filters.options.donors.exomiser.acmg_classification.LIKELY_PATHOGENIC',
+          ),
+          UNCERTAIN_SIGNIFICANCE: intl.get(
+            'filters.options.donors.exomiser.acmg_classification.UNCERTAIN_SIGNIFICANCE',
+          ),
+          LIKELY_BENIGN: intl.get(
+            'filters.options.donors.exomiser.acmg_classification.LIKELY_BENIGN',
+          ),
+          BENIGN: intl.get('filters.options.donors.exomiser.acmg_classification.BENIGN'),
+        },
         'cmc.tier': {
           1: intl.get('filters.options.cmc.tier.1'),
           2: intl.get('filters.options.cmc.tier.2'),


### PR DESCRIPTION
# FIX : [Query] Formatter la valeur comme dans la facette

- closes #CLIN-2156

## Description
La valeur affichée dans la requête doit être dans le même format que dans la facette.

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2156)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/bba46d83-72ba-4e6a-a3f8-d8667a43f205)
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/27ec2e26-1e8f-4664-8792-38df268cce5d)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/80f77fab-4d79-4db5-aa1c-339d6e205a32)
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/4504bec0-6382-4c8d-8e60-8c1cc57a975c)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

