### PR TITLE
fix: CLIN-2283 duplicate tooltip on safari

### DIFF
--- a/src/views/Cnv/Exploration/variantColumns.module.scss
+++ b/src/views/Cnv/Exploration/variantColumns.module.scss
@@ -9,6 +9,12 @@
   white-space: nowrap;
 }
 
+// prevent safari double tooltip
+.variantTableCellElipsis::after {
+  content: '';
+  display: block;
+}
+
 .variantTableCell {
   min-width: 160px;
 }

--- a/src/views/Snv/Exploration/variantColumns.module.scss
+++ b/src/views/Snv/Exploration/variantColumns.module.scss
@@ -10,7 +10,19 @@
       overflow-wrap: unset;
       white-space: nowrap;
     }
+
+    // prevent safari double tooltip
+    div::after {
+      content: '';
+      display: block;
+    }
   }
+}
+
+// prevent safari double tooltip
+.variantTableCellElipsis::after {
+  content: '';
+  display: block;
 }
 
 .variantTableCell {
@@ -64,6 +76,12 @@
     overflow-wrap: unset;
     white-space: nowrap;
   }
+
+  div::after {
+    content: '';
+    display: block;
+  }
+
 }
 
 .hotspotFilled{

--- a/src/views/Snv/components/ConsequencesCell/index.module.scss
+++ b/src/views/Snv/components/ConsequencesCell/index.module.scss
@@ -29,6 +29,12 @@
   white-space: nowrap;
 }
 
+// prevent safari double tooltip
+.detail::after {
+  content: '';
+  display: block;
+}
+
 .bullet {
   margin-right: 8px;
 }


### PR DESCRIPTION
#BUG | remove double tooltip on safari

- closes https://ferlab-crsj.atlassian.net/browse/CLICE-245

## Description

no double tooltip on safari

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done

## Screenshot 

### After

![image](https://github.com/kids-first/kf-portal-ui/assets/98903/c8b5e447-9304-41a2-b330-ae65b45a38f9)
