### PR TITLE
fix: CLIN-2033 [Tableaux] Affichage brisé lorsqu'il n'y a pas de donnée

### DIFF
--- a/src/views/Cnv/Exploration/Patient/components/PageContent/components/Variants/index.tsx
+++ b/src/views/Cnv/Exploration/Patient/components/PageContent/components/Variants/index.tsx
@@ -87,7 +87,12 @@ const VariantsTable = ({
           <ProTable<ITableVariantEntity>
             tableId="variant_table"
             wrapperClassName={style.variantTableWrapper}
-            columns={getVariantColumns(variantType, openGenesModal, openIgvModal)}
+            columns={getVariantColumns(
+              variantType,
+              openGenesModal,
+              openIgvModal,
+              results.data.length === 0 ? true : false,
+            )}
             initialColumnState={initialColumnState}
             dataSource={results.data.map((i) => ({ ...i, key: `${i[VARIANT_KEY]}` }))}
             loading={results.loading}

--- a/src/views/Cnv/Exploration/variantColumns.tsx
+++ b/src/views/Cnv/Exploration/variantColumns.tsx
@@ -18,6 +18,7 @@ export const getVariantColumns = (
   variantType: VariantType,
   openGenesModal: (record: VariantEntity) => void,
   igvModalCb?: (record: VariantEntity) => void,
+  noData: boolean = false,
 ): ProColumnType<ITableVariantEntity>[] => {
   const columns: ProColumnType<ITableVariantEntity>[] = [];
 
@@ -26,7 +27,7 @@ export const getVariantColumns = (
       className: style.userAffectedBtnCell,
       key: 'actions',
       title: intl.get('screen.patientsnv.results.table.actions'),
-      fixed: 'left',
+      fixed: noData ? undefined : 'left',
       render: (record: VariantEntity) => (
         <Space align={'center'}>
           <Tooltip title={intl.get('open.in.igv')}>

--- a/src/views/Prescriptions/Entity/GenericCoverage/columns.tsx
+++ b/src/views/Prescriptions/Entity/GenericCoverage/columns.tsx
@@ -52,12 +52,13 @@ const handleRedirection = (
 export const getGeneCoverageTableColumns = (
   igvModalCb: (record: ITableGeneCoverage) => void,
   history: any,
+  noData: boolean = false,
 ): ProColumnType<ITableGeneCoverage>[] => [
   {
     className: style.userAffectedBtnCell,
     key: 'actions',
     title: intl.get('screen.patientsnv.results.table.actions'),
-    fixed: 'left',
+    fixed: noData ? undefined : 'left',
     render: (record: ITableGeneCoverage) => (
       <Space align={'center'}>
         <Tooltip title={intl.get('open.in.igv')}>

--- a/src/views/Prescriptions/Entity/GenericCoverage/index.tsx
+++ b/src/views/Prescriptions/Entity/GenericCoverage/index.tsx
@@ -213,7 +213,11 @@ const Index = ({ downloadFile }: any) => {
           fixedProTable={(dimension) => (
             <ProTable<ITableGeneCoverage>
               tableId="general-coverage-genes"
-              columns={getGeneCoverageTableColumns(openIgvModal, history)}
+              columns={getGeneCoverageTableColumns(
+                openIgvModal,
+                history,
+                data.length === 0 ? true : false,
+              )}
               initialColumnState={initialColumnState}
               scroll={dimension}
               dataSource={data}

--- a/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
+++ b/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
@@ -85,8 +85,9 @@ const VariantsTab = ({
     patientId,
     openDrawer,
     openIgvModal,
+    undefined,
+    results.data.length === 0 ? true : false,
   );
-
   return (
     <>
       {donor && selectedVariant && (

--- a/src/views/Snv/Exploration/Rqdm/PageContent/tabs/Variants/index.tsx
+++ b/src/views/Snv/Exploration/Rqdm/PageContent/tabs/Variants/index.tsx
@@ -58,7 +58,15 @@ const VariantsTab = ({
           tableId="varirant_table"
           className={style.variantSearchTable}
           wrapperClassName={style.variantTabWrapper}
-          columns={getVariantColumns(queryBuilderId, VariantType.GERMLINE)}
+          columns={getVariantColumns(
+            queryBuilderId,
+            VariantType.GERMLINE,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            results.data.length === 0 ? true : false,
+          )}
           initialColumnState={initialColumnState}
           dataSource={results.data.map((i) => ({ ...i, key: `${i[VARIANT_KEY]}` }))}
           loading={results.loading}

--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -230,7 +230,6 @@ export const getVariantColumns = (
         </Space>
       ),
       align: 'center',
-      width: 102,
     });
   }
 

--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import intl from 'react-intl-universal';
@@ -197,6 +198,7 @@ export const getVariantColumns = (
   drawerCb?: (record: VariantEntity) => void,
   igvModalCb?: (record: VariantEntity) => void,
   onlyExportTSV: boolean = false,
+  noData: boolean = false,
 ): ProColumnType<ITableVariantEntity>[] => {
   let columns: ProColumnType<ITableVariantEntity>[] = [];
 
@@ -205,7 +207,7 @@ export const getVariantColumns = (
       className: style.userAffectedBtnCell,
       key: 'actions',
       title: intl.get('screen.patientsnv.results.table.actions'),
-      fixed: 'left',
+      fixed: noData ? undefined : 'left',
       render: (record: VariantEntity) => (
         <Space align={'center'}>
           <Tooltip title={intl.get('occurrence.patient')}>
@@ -240,7 +242,7 @@ export const getVariantColumns = (
       key: 'hgvsg',
       dataIndex: 'hgvsg',
       className: style.fixedVariantTableCellElipsis,
-      fixed: 'left',
+      fixed: noData ? undefined : 'left',
       sorter: {
         multiple: 1,
       },


### PR DESCRIPTION
# FIX : [Tableaux] Affichage brisé lorsqu'il n'y a pas de donnée

- closes #CLIN-2033

## Description
L’affichage des colonnes est brisé quand on les affiche toutes et qu’il n’y a pas de données dans le tableau

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2033)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/ecf07c62-e718-4b6f-b2c8-5f6a43191ddc)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/ee391a3e-c345-4046-91ec-5b6d1f7eed3d)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

