### PR TITLE
fix: CLIN-2319 tsv picked gene symbol

### DIFF
--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -804,10 +804,11 @@ export const renderClinvarToString = (variant: any) => {
   return clinvarStringList.join(',');
 };
 export const renderGeneToString = (variant: any) => {
-  const genes = variant.genes?.hits.edges;
-
-  if (genes?.length && genes[0].node.symbol) {
-    return genes[0].node.symbol;
+  const pickedConsequence = variant.consequences?.hits.edges.find(
+    ({ node }: any) => !!node.picked,
+  )?.node;
+  if (pickedConsequence && pickedConsequence.symbol) {
+    return pickedConsequence.symbol;
   }
 
   return TABLE_EMPTY_PLACE_HOLDER;

--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -804,10 +804,10 @@ export const renderClinvarToString = (variant: any) => {
   return clinvarStringList.join(',');
 };
 export const renderGeneToString = (variant: any) => {
-  const pickedConsequence = variant.consequences?.hits.edges.find(
+  const pickedConsequence = variant.consequences?.hits?.edges?.find(
     ({ node }: any) => !!node.picked,
   )?.node;
-  if (pickedConsequence && pickedConsequence.symbol) {
+  if (pickedConsequence?.symbol) {
     return pickedConsequence.symbol;
   }
 


### PR DESCRIPTION
# FIX : tsv picked gene symbol

- closes #CLIN-2319

## Description
Les variants exportés dans le TSV doivent afficher les mêmes valeurs que celles listées dans le tableau

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2319)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/417b0055-4052-4780-aa38-d6b24064f29c)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/76ebc663-12c8-4fa4-bf5e-a35485bd5724)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

