### PR TITLE
fix: CLIN-2344  Glitch au switch entre variants germinaux et somatiques

### DIFF
--- a/src/api/user/models.ts
+++ b/src/api/user/models.ts
@@ -22,7 +22,8 @@ export type TUserConfig = {
   data_exploration?: {
     tables?: {
       archives?: TUserTableConfig;
-      patientSnv?: TUserTableConfig;
+      patientSnvSomatique?: TUserTableConfig;
+      patientSnvGermline?: TUserTableConfig;
       patientCnv?: TUserTableConfig;
       prescriptions?: TUserTableConfig;
       prescriptionEntityFiles?: TUserTableConfig;

--- a/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
+++ b/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
@@ -72,9 +72,14 @@ const VariantsTab = ({
   };
 
   const donor = findDonorById(selectedVariant?.donors, patientId);
-  const initialColumnState = user.config.data_exploration?.tables?.patientSnv?.columns;
 
   const variantType = getVariantTypeFromSNVVariantEntity(results.data?.[0]);
+
+  const initialColumnState =
+    variantType === VariantType.GERMLINE
+      ? user.config.data_exploration?.tables?.patientSnvGermline?.columns
+      : user.config.data_exploration?.tables?.patientSnvSomatique?.columns;
+
   setVariantType(variantType);
   const columns = getVariantColumns(
     queryBuilderId,
@@ -140,13 +145,21 @@ const VariantsTab = ({
               },
               onColumnSortChange: (columns) => {
                 dispatch(
-                  updateConfig({
-                    data_exploration: {
-                      tables: {
-                        patientSnv: { columns },
-                      },
-                    },
-                  }),
+                  variantType === VariantType.GERMLINE
+                    ? updateConfig({
+                        data_exploration: {
+                          tables: {
+                            patientSnvGermline: { columns },
+                          },
+                        },
+                      })
+                    : updateConfig({
+                        data_exploration: {
+                          tables: {
+                            patientSnvSomatique: { columns },
+                          },
+                        },
+                      }),
                 );
               },
             }}
@@ -162,16 +175,27 @@ const VariantsTab = ({
               },
               onViewQueryChange: (viewPerQuery: PaginationViewPerQuery) => {
                 dispatch(
-                  updateConfig({
-                    data_exploration: {
-                      tables: {
-                        patientSnv: {
-                          ...user?.config.data_exploration?.tables?.patientSnv,
-                          viewPerQuery,
+                  variantType === VariantType.GERMLINE
+                    ? updateConfig({
+                        data_exploration: {
+                          tables: {
+                            patientSnvGermline: {
+                              ...user?.config.data_exploration?.tables?.patientSnvGermline,
+                              viewPerQuery,
+                            },
+                          },
                         },
-                      },
-                    },
-                  }),
+                      })
+                    : updateConfig({
+                        data_exploration: {
+                          tables: {
+                            patientSnvSomatique: {
+                              ...user?.config.data_exploration?.tables?.patientSnvSomatique,
+                              viewPerQuery,
+                            },
+                          },
+                        },
+                      }),
                 );
               },
               searchAfter: results.searchAfter,


### PR DESCRIPTION
# FIX | FEAT | REFACTOR | PERF | DOCS : [Colonnes] Glitch au switch entre variants germinaux et somatiques

- closes #CLIN-2344

## Description
Les colonnes ne s’affichent pas dans le bon ordre et un Reset et nécessaire au switch entre la page des variants d’un patient germinaux et somatiques.

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2344)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

