### PR TITLE
fix: CLIN-2366 [Search After] La combinaison Next/Prev. avec le sort ne fonctionne pas

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,4 +1,5 @@
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { ISort } from '@ferlab/ui/core/graphql/types';
 import { SorterResult } from 'antd/lib/table/interface';
 import { isArray } from 'lodash';
 
@@ -63,10 +64,16 @@ export const scrollToTop = (scrollContentId: string) =>
 export const getOrderFromAntdValue = (order: string): SortDirection =>
   order === 'ascend' ? SortDirection.Asc : SortDirection.Desc;
 
-export const formatQuerySortList = (sorter: SorterResult<any> | SorterResult<any>[]) => {
+export const formatQuerySortList = (
+  sorter: SorterResult<any> | SorterResult<any>[],
+  defaultSorter: ISort[],
+) => {
   const sorters = (isArray(sorter) ? sorter : [sorter]).filter(
     (sorter) => !!sorter.column || !!sorter.order,
   );
+  if (sorters.length === 0) {
+    return defaultSorter;
+  }
 
   const r = sorters.map((sorter) => {
     let field = (sorter.field?.toString()! || sorter.columnKey?.toString()!)?.replaceAll('__', '.');

--- a/src/utils/tests/helper.spec.js
+++ b/src/utils/tests/helper.spec.js
@@ -1,7 +1,53 @@
-import { downloadText } from 'utils/helper';
+import { downloadText, formatQuerySortList } from 'utils/helper';
 
 describe('downloadText', () => {
   test('Should be robust', () => {
     downloadText(null, 'file.tsv');
+  });
+});
+
+describe('Table sort', () => {
+  test('Should return default sort if no sorter', () => {
+    const sorting = {
+      field: ['column2'],
+      columnKey: 'column2',
+    };
+    const defaultSort = [
+      {
+        field: 'column1',
+        order: 'desc',
+      },
+    ];
+
+    expect(formatQuerySortList(sorting, defaultSort)).toEqual(defaultSort);
+  });
+  test('Should return correct column sort', () => {
+    const sorting = {
+      column: {
+        key: 'column2',
+        dataIndex: ['column2'],
+        title: 'column Test',
+        sorter: { multiple: 1 },
+      },
+      order: 'ascend',
+      field: ['column2'],
+      columnKey: 'column2',
+    };
+
+    const defaultSort = [
+      {
+        field: 'column1',
+        order: 'desc',
+      },
+    ];
+
+    const expectedSort = [
+      {
+        field: 'column2',
+        order: 'asc',
+      },
+    ];
+
+    expect(formatQuerySortList(sorting, defaultSort)).toEqual(expectedSort);
   });
 });

--- a/src/views/Cnv/Exploration/Patient/components/PageContent/components/Variants/index.tsx
+++ b/src/views/Cnv/Exploration/Patient/components/PageContent/components/Variants/index.tsx
@@ -8,7 +8,11 @@ import { IQueryResults } from 'graphql/models';
 import GenesModal from 'views/Cnv/Exploration/components/GenesModal';
 import IGVModal from 'views/Cnv/Exploration/components/IGVModal';
 import { getVariantColumns } from 'views/Cnv/Exploration/variantColumns';
-import { DEFAULT_PAGE_INDEX, SCROLL_WRAPPER_ID } from 'views/Cnv/utils/constant';
+import {
+  DEFAULT_PAGE_INDEX,
+  DEFAULT_SORT_QUERY,
+  SCROLL_WRAPPER_ID,
+} from 'views/Cnv/utils/constant';
 import { getVariantTypeFromCNVVariantEntity } from 'views/Prescriptions/Entity/Tabs/Variants/utils';
 import { VARIANT_KEY } from 'views/Prescriptions/utils/export';
 
@@ -102,7 +106,7 @@ const VariantsTable = ({
                 pageIndex: DEFAULT_PAGE_INDEX,
                 size: queryConfig.size!,
                 // @ts-ignore
-                sort: formatQuerySortList(sorter),
+                sort: formatQuerySortList(sorter, DEFAULT_SORT_QUERY),
               });
             }}
             bordered

--- a/src/views/Prescriptions/Entity/GenericCoverage/index.tsx
+++ b/src/views/Prescriptions/Entity/GenericCoverage/index.tsx
@@ -316,7 +316,7 @@ const Index = ({ downloadFile }: any) => {
                 setQueryConfig({
                   pageIndex: DEFAULT_PAGE_INDEX,
                   size: queryConfig.size,
-                  sort: formatQuerySortList(sorter),
+                  sort: formatQuerySortList(sorter, DEFAULT_COVERAGE_SORT),
                 } as IQueryConfig);
               }}
               dictionary={getProTableDictionary()}

--- a/src/views/Prescriptions/Search/components/table/PrescriptionTable/index.tsx
+++ b/src/views/Prescriptions/Search/components/table/PrescriptionTable/index.tsx
@@ -8,6 +8,7 @@ import { GqlResults } from 'graphql/models';
 import { AnalysisResult, ITableAnalysisResult } from 'graphql/prescriptions/models/Prescription';
 import {
   DEFAULT_PAGE_INDEX,
+  DEFAULT_SORT_QUERY,
   PRESCRIPTION_QB_ID,
   PRESCRIPTION_SCROLL_ID,
 } from 'views/Prescriptions/Search/utils/contstant';
@@ -74,8 +75,10 @@ const PrescriptionsTable = ({
         setQueryConfig({
           pageIndex: DEFAULT_PAGE_INDEX,
           size: queryConfig.size!,
-          // @ts-ignore
-          sort: action.action === 'sort' ? formatQuerySortList(sorter) : queryConfig.sort,
+          sort:
+            action.action === 'sort'
+              ? formatQuerySortList(sorter, DEFAULT_SORT_QUERY)
+              : queryConfig.sort,
         });
         scrollToTop(PRESCRIPTION_SCROLL_ID);
       }}

--- a/src/views/Prescriptions/Search/components/table/SequencingTable/index.tsx
+++ b/src/views/Prescriptions/Search/components/table/SequencingTable/index.tsx
@@ -57,13 +57,11 @@ const SequencingsTable = ({
       dictionary={getProTableDictionary()}
       showSorterTooltip={false}
       bordered
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      onChange={(_, sorter) => {
+      onChange={(_, __, sorter) => {
         setPageIndex(DEFAULT_PAGE_INDEX);
         setQueryConfig({
           pageIndex: DEFAULT_PAGE_INDEX,
           size: queryConfig.size!,
-          // @ts-ignore
           sort: formatQuerySortList(sorter, DEFAULT_SORT_QUERY),
         });
         scrollToTop(SEQUENCING_SCROLL_ID);

--- a/src/views/Prescriptions/Search/components/table/SequencingTable/index.tsx
+++ b/src/views/Prescriptions/Search/components/table/SequencingTable/index.tsx
@@ -7,6 +7,7 @@ import { GqlResults } from 'graphql/models';
 import { ITableSequencingResult, SequencingResult } from 'graphql/sequencing/models';
 import {
   DEFAULT_PAGE_INDEX,
+  DEFAULT_SORT_QUERY,
   SEQUENCING_SCROLL_ID,
 } from 'views/Prescriptions/Search/utils/contstant';
 import { ALL_KEYS } from 'views/Prescriptions/utils/export';
@@ -57,13 +58,13 @@ const SequencingsTable = ({
       showSorterTooltip={false}
       bordered
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      onChange={({ current }, _, sorter) => {
+      onChange={(_, sorter) => {
         setPageIndex(DEFAULT_PAGE_INDEX);
         setQueryConfig({
           pageIndex: DEFAULT_PAGE_INDEX,
           size: queryConfig.size!,
           // @ts-ignore
-          sort: formatQuerySortList(sorter),
+          sort: formatQuerySortList(sorter, DEFAULT_SORT_QUERY),
         });
         scrollToTop(SEQUENCING_SCROLL_ID);
       }}

--- a/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
+++ b/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
@@ -12,7 +12,11 @@ import { VARIANT_KEY } from 'views/Prescriptions/utils/export';
 import IGVModal from 'views/Snv/components//IGVModal';
 import OccurrenceDrawer from 'views/Snv/components/OccurrenceDrawer';
 import { getVariantColumns } from 'views/Snv/Exploration/variantColumns';
-import { DEFAULT_PAGE_INDEX, SCROLL_WRAPPER_ID } from 'views/Snv/utils/constant';
+import {
+  DEFAULT_PAGE_INDEX,
+  DEFAULT_SORT_QUERY,
+  SCROLL_WRAPPER_ID,
+} from 'views/Snv/utils/constant';
 
 import FixedSizeTable from 'components/Layout/FixedSizeTable';
 import { useRpt } from 'hooks/useRpt';
@@ -110,13 +114,13 @@ const VariantsTab = ({
             dictionary={getProTableDictionary()}
             showSorterTooltip={false}
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onChange={(_, __, sorter) => {
+            onChange={(_, sorter) => {
               setPageIndex(DEFAULT_PAGE_INDEX);
               setQueryConfig({
                 pageIndex: DEFAULT_PAGE_INDEX,
                 size: queryConfig.size!,
                 // @ts-ignore
-                sort: formatQuerySortList(sorter),
+                sort: formatQuerySortList(sorter, DEFAULT_SORT_QUERY),
               });
             }}
             bordered

--- a/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
+++ b/src/views/Snv/Exploration/Patient/PageContent/tabs/Variants/index.tsx
@@ -114,7 +114,7 @@ const VariantsTab = ({
             dictionary={getProTableDictionary()}
             showSorterTooltip={false}
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onChange={(_, sorter) => {
+            onChange={(_, __, sorter) => {
               setPageIndex(DEFAULT_PAGE_INDEX);
               setQueryConfig({
                 pageIndex: DEFAULT_PAGE_INDEX,

--- a/src/views/Snv/Exploration/Rqdm/PageContent/tabs/Variants/index.tsx
+++ b/src/views/Snv/Exploration/Rqdm/PageContent/tabs/Variants/index.tsx
@@ -6,7 +6,11 @@ import { ITableVariantEntity, VariantEntity } from 'graphql/variants/models';
 import { VariantType } from 'views/Prescriptions/Entity/context';
 import { VARIANT_KEY } from 'views/Prescriptions/utils/export';
 import { getVariantColumns } from 'views/Snv/Exploration/variantColumns';
-import { DEFAULT_PAGE_INDEX, SCROLL_WRAPPER_ID } from 'views/Snv/utils/constant';
+import {
+  DEFAULT_PAGE_INDEX,
+  DEFAULT_SORT_QUERY,
+  SCROLL_WRAPPER_ID,
+} from 'views/Snv/utils/constant';
 
 import FixedSizeTable from 'components/Layout/FixedSizeTable';
 import { useUser } from 'store/user';
@@ -76,7 +80,7 @@ const VariantsTab = ({
               pageIndex: DEFAULT_PAGE_INDEX,
               size: queryConfig.size!,
               // @ts-ignore
-              sort: formatQuerySortList(sorter),
+              sort: formatQuerySortList(sorter, DEFAULT_SORT_QUERY),
             });
           }}
           bordered


### PR DESCRIPTION
# FIX: [Search After] La combinaison Next/Prev. avec le sort ne fonctionne pas

- closes #CLIN-2366

## Description
Pour reproduire:

- Trier une colonne
- Cliquer 2 fois pour retirer le trie de la colonne
- Cliquer sur Suivant
- Cliquer sur Précédent
-

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2366)


Steps to validate
Url (storybook, ...)
...

## Mention

