### PR TITLE
fix: CLIN-2384 fix cnv nb genes

### DIFF
--- a/src/views/Cnv/Exploration/variantColumns.tsx
+++ b/src/views/Cnv/Exploration/variantColumns.tsx
@@ -158,7 +158,7 @@ export const getVariantColumns = (
       tooltip: intl.get('screen.patientcnv.results.table.number_genes.tooltip'),
       key: 'number_genes',
       dataIndex: 'number_genes',
-      width: 82,
+      width: 85,
       sorter: { multiple: 1 },
       render: (number_genes: number, variant: VariantEntity) =>
         number_genes !== 0 ? (

--- a/src/views/Cnv/Exploration/variantColumns.tsx
+++ b/src/views/Cnv/Exploration/variantColumns.tsx
@@ -158,7 +158,7 @@ export const getVariantColumns = (
       tooltip: intl.get('screen.patientcnv.results.table.number_genes.tooltip'),
       key: 'number_genes',
       dataIndex: 'number_genes',
-      width: 65,
+      width: 82,
       sorter: { multiple: 1 },
       render: (number_genes: number, variant: VariantEntity) =>
         number_genes !== 0 ? (

--- a/src/views/Cnv/Exploration/variantColumns.tsx
+++ b/src/views/Cnv/Exploration/variantColumns.tsx
@@ -158,18 +158,21 @@ export const getVariantColumns = (
       tooltip: intl.get('screen.patientcnv.results.table.number_genes.tooltip'),
       key: 'number_genes',
       dataIndex: 'number_genes',
-      width: 60,
+      width: 65,
       sorter: { multiple: 1 },
-      render: (number_genes: number, variant: VariantEntity) => (
-        <a
-          onClick={(e) => {
-            e.preventDefault();
-            openGenesModal(variant);
-          }}
-        >
-          {number_genes}
-        </a>
-      ),
+      render: (number_genes: number, variant: VariantEntity) =>
+        number_genes !== 0 ? (
+          <a
+            onClick={(e) => {
+              e.preventDefault();
+              openGenesModal(variant);
+            }}
+          >
+            {number_genes}
+          </a>
+        ) : (
+          <>{number_genes}</>
+        ),
     },
     {
       title: intl.get('screen.patientcnv.results.table.genotype'),


### PR DESCRIPTION
# FIX : [CNVs] Ajustements à la colonne #Gènes

- closes #CLIN-2384

## Description
Dans la page des CNVs d’un patient, la colonne #Gènes semble trop étroite et il ne devrait pas y avoir de lien si le nombre est 0.

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2384)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/e8b4c91f-55a3-4dc1-90ce-9a9d351d8488)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/953910d6-bc36-4336-abba-e2d2147c3ee6)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

