### PR TITLE
feat: CLIN-2558 zygosity occurence

### DIFF
--- a/cypress/e2e/Consultation/TiroirOccurrence.cy.ts
+++ b/cypress/e2e/Consultation/TiroirOccurrence.cy.ts
@@ -15,7 +15,7 @@ describe('Tiroir d\'une occurrence', () => {
     cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(0).find('tr[class="ant-descriptions-row"]').eq(0).contains('chr10:g.113623545C>T').should('exist');
     cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(0).find('tr[class="ant-descriptions-row"]').eq(1).contains(epCHUSJ_ldmCHUSJ.patientProbId).should('exist');
 
-    cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(1).find('tr[class="ant-descriptions-row"]').eq(0).contains('HET').should('exist');
+    cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(1).find('tr[class="ant-descriptions-row"]').eq(0).contains('0/1').should('exist');
     cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(1).find('tr[class="ant-descriptions-row"]').eq(1).contains('NRAP').should('exist');
     cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(1).find('tr[class="ant-descriptions-row"]').eq(1).contains('( 3 )').should('exist');
     cy.get('div[class*="ant-drawer-open"]').find('div[class*="OccurrenceDrawer_description"]').eq(1).find('tr[class="ant-descriptions-row"]').eq(2).contains('NRAP').should('exist');

--- a/src/views/Snv/components/OccurrenceDrawer/index.tsx
+++ b/src/views/Snv/components/OccurrenceDrawer/index.tsx
@@ -7,6 +7,7 @@ import { Rpt } from 'auth/types';
 import cx from 'classnames';
 import { DonorsEntity, VariantType } from 'graphql/variants/models';
 import capitalize from 'lodash/capitalize';
+import { ZygosityValue } from 'views/Snv/utils/constant';
 
 import ExternalLinkIcon from 'components/icons/ExternalLinkIcon';
 import FemaleAffectedIcon from 'components/icons/FemaleAffectedIcon';
@@ -115,7 +116,7 @@ const OccurrenceDrawer = ({
             title={capitalize(intl.get('zygosity'))}
           >
             <Descriptions.Item label={capitalize(intl.get('zygosity'))}>
-              {donor?.zygosity ?? TABLE_EMPTY_PLACE_HOLDER}
+              {donor?.zygosity ? ZygosityValue[donor.zygosity] : TABLE_EMPTY_PLACE_HOLDER}
             </Descriptions.Item>
             {variantType === VariantType.GERMLINE && (
               <>


### PR DESCRIPTION
#FEAT  : Afficher la zygosité dans sa forme allélique dans l'occurence

- closes #CLIN-2558

## Description
Dans le volet d'occurrence la zygosité est affichée avec HET, HOM et HEM il faut la mettre sous la forme 1/1 0/1 1, comme dans les tableau pour la colonne Zyg.

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2558)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

