### PR TITLE
feat: CLIN-2686 ajout dictionaries cnv snv

### DIFF
--- a/cypress/e2e/Facettes/DictionnairesCNVsPatient.cy.ts
+++ b/cypress/e2e/Facettes/DictionnairesCNVsPatient.cy.ts
@@ -35,8 +35,10 @@ describe('Page des CNVs d\'un patient - Dictionnaire', () => {
 
   it('Variant - Type de variant', () => {
     const dictionnary = ['GAIN',
-                          'LOSS',
-                          'No Data'];
+                         'LOSS',
+                         'GAINLOH',
+                         'CNLOH',
+                         'No Data'];
 
     cy.visitCNVsPatientPage(epCHUSJ_ldmCHUSJ.patientProbId, epCHUSJ_ldmCHUSJ.prescriptionId, 3, '?sharedFilterId=92e4e5c0-5b1e-4521-a140-f4e28b2bf420');
     cy.validateDictionnaryPresetValues('Variant', 'Type de variant', dictionnary);
@@ -109,6 +111,8 @@ describe('Page des CNVs d\'un patient - Dictionnaire', () => {
                          'CnvQual',
                          'CnvCopyRatio',
                          'LoDFail',
+                         'BinCount',
+                         'SegmentMean',
                          'No Data'];
 
     cy.visitCNVsPatientPage(epCHUSJ_ldmCHUSJ.patientProbId, epCHUSJ_ldmCHUSJ.prescriptionId, 3, '?sharedFilterId=92e4e5c0-5b1e-4521-a140-f4e28b2bf420');

--- a/cypress/e2e/Facettes/DictionnairesVariantsPatient.cy.ts
+++ b/cypress/e2e/Facettes/DictionnairesVariantsPatient.cy.ts
@@ -587,6 +587,7 @@ describe('Page des variants d\'un patient - Dictionnaire', () => {
                          'Read Position',
                          'Multiallelic',
                          'Long Indel',
+                         'Low Tlen',
                          'No Data'];
 
     cy.visitVariantsPatientPage(epCHUSJ_ldmCHUSJ.patientProbId, epCHUSJ_ldmCHUSJ.prescriptionId, 3, 'd3eefb82-edcc-42f1-a4e6-28808bd06f34');

--- a/src/graphql/utils/dictionaries.ts
+++ b/src/graphql/utils/dictionaries.ts
@@ -39,7 +39,7 @@ export const dictionaries: Record<string, string[]> = {
   'donors.affected_status_code': ['affected', 'not_affected', 'unknown'],
   'donors.gender': ['Female', 'Male', 'Other', 'unknown'],
   // Variants
-  type: ['GAIN', 'LOSS', ArrangerValues.missing],
+  type: ['GAIN', 'LOSS', 'GAINLOH', 'CNLOH', ArrangerValues.missing],
   variant_class: [
     'insertion',
     'deletion',
@@ -382,7 +382,16 @@ export const dictionaries: Record<string, string[]> = {
     'read_position',
     'multiallelic',
     'long_indel',
+    'low_tlen',
     ArrangerValues.missing,
   ],
-  filters: ['PASS', 'cnvQual', 'cnvCopyRatio', 'LoDFail', ArrangerValues.missing],
+  filters: [
+    'PASS',
+    'cnvQual',
+    'cnvCopyRatio',
+    'LoDFail',
+    'binCount',
+    'segmentMean',
+    ArrangerValues.missing,
+  ],
 };


### PR DESCRIPTION
# FEAT : [CNV] Mettre à jour dictionnaire des types de variant

- closes #CLIN-2686

## Description
**CNV**  
Facette “variant type ”(Values GAINLOH, CNLOH )
Facette “Filtre (Dragen) ” (Values binCount, segmentMean)

**SNV**
Facette “Filtre (Dragen) ” (Value low_tlen)

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2686)


