### PR TITLE
fix: CLIN-2842 rqdm width

### DIFF
--- a/src/views/Snv/Exploration/variantColumns.tsx
+++ b/src/views/Snv/Exploration/variantColumns.tsx
@@ -618,7 +618,7 @@ export const getVariantColumns = (
     sorter: {
       multiple: 1,
     },
-    width: 110,
+    width: 120,
     render: (record: VariantEntity) => formatRqdm(record.frequency_RQDM, record),
   });
 


### PR DESCRIPTION
# FIX : rqdm width

- closes #CLIN-2842

## Description
L’affichage de la valeur est sur une seule ligne.

Pour tous les tableau contenant cette colonne.

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2842)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/e10b7fe4-bbe8-41d3-b767-7266ed5f4ab4)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/5d2fbce4-fb67-4c08-abfb-23ead716bea4)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

