### PR TITLE
feat: CLIN-2862 enlever link si non autorise

### DIFF
--- a/cypress/e2e/AccesUtilisateurs/ParRole.cy.ts
+++ b/cypress/e2e/AccesUtilisateurs/ParRole.cy.ts
@@ -432,6 +432,7 @@ describe('Accès des utilisateurs', () => {
     // Accéder à la page Prescription d'un patient du CUSM (LDM: CHUSJ)
     cy.visitPrescriptionEntityPage(epCUSM_ldmCHUSJ.prescriptionId);
     cy.contains(epCUSM_ldmCHUSJ.firstNameProb).should('exist');
+    cy.contains('Fichiers').eq(1).should('not.exist');
     // Accéder aux variants d'un patient du CUSM (LDM: CHUSJ) est impossible
     cy.visit(`/snv/exploration/patient/${epCUSM_ldmCHUSJ.patientProbId}/${epCUSM_ldmCHUSJ.prescriptionId}`);
     cy.contains('403').should('exist', { timeout: 20 * 1000 });
@@ -439,6 +440,7 @@ describe('Accès des utilisateurs', () => {
     // Accéder à la page Prescription d'un patient du CUSM (LDM: CUSM)
     cy.visitPrescriptionEntityPage(epCUSM_ldmCUSM.prescriptionId);
     cy.contains(epCUSM_ldmCUSM.firstNameProb).should('exist');
+    cy.contains('Fichiers').eq(1).should('not.exist');
     // Accéder aux variants d'un patient du CUSM (LDM: CUSM) est impossible
     cy.visit(`/snv/exploration/patient/${epCUSM_ldmCUSM.patientProbId}/${epCUSM_ldmCUSM.prescriptionId}`);
     cy.contains('403').should('exist', { timeout: 20 * 1000 });
@@ -475,6 +477,7 @@ describe('Accès des utilisateurs', () => {
     // Accéder à la page Prescription d'un patient du CHUSJ
     cy.visitPrescriptionEntityPage(epCHUSJ_ldmCHUSJ.prescriptionId);
     cy.contains(epCHUSJ_ldmCHUSJ.firstNameProb).should('exist');
+    cy.contains('Fichiers').eq(1).should('not.exist');
     // Accéder aux variants d'un patient du CHUSJ est impossible
     cy.visit(`/snv/exploration/patient/${epCHUSJ_ldmCHUSJ.patientProbId}/${epCHUSJ_ldmCHUSJ.prescriptionId}`);
     cy.contains('403').should('exist', { timeout: 20 * 1000 });

--- a/src/views/Prescriptions/Entity/tests/__snapshots__/RequestTable.test.jsx.snap
+++ b/src/views/Prescriptions/Entity/tests/__snapshots__/RequestTable.test.jsx.snap
@@ -83,16 +83,6 @@ exports[`RequestTable should be as the snapshot 1`] = `
                   >
                     Échantillon
                   </th>
-                  <th
-                    className="ant-table-cell"
-                    colSpan={null}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    rowSpan={null}
-                    style={Object {}}
-                  >
-                    Liens
-                  </th>
                 </tr>
               </thead>
               <tbody
@@ -108,7 +98,7 @@ exports[`RequestTable should be as the snapshot 1`] = `
                 >
                   <td
                     className="ant-table-cell"
-                    colSpan={6}
+                    colSpan={5}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     rowSpan={null}

--- a/src/views/Prescriptions/components/Links/index.tsx
+++ b/src/views/Prescriptions/components/Links/index.tsx
@@ -4,7 +4,6 @@ import { FileTextOutlined } from '@ant-design/icons';
 import { Space } from 'antd';
 import { extractServiceRequestId } from 'api/fhir/helper';
 
-import { LimitTo, Roles } from 'components/Roles/Rules';
 import { STATIC_ROUTES } from 'utils/routes';
 
 interface OwnProps {
@@ -15,19 +14,17 @@ interface OwnProps {
 const Links = ({ prescriptionId, withDownload = true }: OwnProps) => (
   <Space size="middle">
     {withDownload && (
-      <LimitTo roles={[Roles.Download]}>
-        <Link
-          to={`${STATIC_ROUTES.ARCHIVE_EXPLORATION}?search=${extractServiceRequestId(
-            prescriptionId,
-          )}`}
-          data-cy={`ArchiveLink_${extractServiceRequestId(prescriptionId)}`}
-        >
-          <Space size={4}>
-            <FileTextOutlined />
-            {intl.get('links.files')}
-          </Space>
-        </Link>
-      </LimitTo>
+      <Link
+        to={`${STATIC_ROUTES.ARCHIVE_EXPLORATION}?search=${extractServiceRequestId(
+          prescriptionId,
+        )}`}
+        data-cy={`ArchiveLink_${extractServiceRequestId(prescriptionId)}`}
+      >
+        <Space size={4}>
+          <FileTextOutlined />
+          {intl.get('links.files')}
+        </Space>
+      </Link>
     )}
   </Space>
 );


### PR DESCRIPTION
# FEAT : Masquer la colonne lien pour les utilisateurs n'ayant accès à aucun lien

- closes #CLIN-2862

## Description
Dans le cas d’un docteur (ex. Félix), puisqu’il n’a pas accès aux liens, ils ne sont pas affichés, ce qui laisse la colonne vide.
Si l’utilisateur ne pourra jamais avoir accès à ces liens, on cache la colonne liens au complet.

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2862)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/d77419ae-625e-4bc4-a030-861166ddc2fc)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

