### PR TITLE
fix: CLIN-2890 fix doublon

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -114,7 +114,6 @@
   "filter.suggester.search.noresults": "No results found",
   "filter.suggester.search.variants": "Search by Variant",
   "filter.suggester.search.variants.tooltip": "Search by locus, dbSNP ID and ClinVar ID",
-  "filters.group.analysis.code": "Analysis",
   "filters.group.analysis.display": "Analysis",
   "filters.group.analysis_code": "Analysis",
   "filters.group.approver.lastNameFirstName": "Approver",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -115,7 +115,6 @@
   "filter.suggester.search.noresults": "Aucun résultat",
   "filter.suggester.search.variants": "Recherche par variant",
   "filter.suggester.search.variants.tooltip": "Recherche par locus, dbSNP ID et ClinVar ID",
-  "filters.group.analysis.code": "Analyse",
   "filters.group.analysis.display": "Analyse",
   "filters.group.analysis_code": "Analyse",
   "filters.group.approver.lastNameFirstName": "Médecin approbateur",


### PR DESCRIPTION
# FIX : Doublon analysis

- closes #CLIN-2890

## Description
Valider la pertinence du quasi doublon pour le filters.group entre analysis_code et analysis.code

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2890)


