### PR TITLE
fix: CLIN-2962 add empty field assignments tsv

### DIFF
--- a/cypress/fixtures/ExportTableauPrescriptions.json
+++ b/cypress/fixtures/ExportTableauPrescriptions.json
@@ -1,5 +1,6 @@
 {
-  "headers": ["prescription_id",
+  "headers": ["assignments",
+              "prescription_id",
               "patient_id",
               "priority",
               "status",
@@ -12,7 +13,8 @@
               "requester",
               "prenatal",
               "patient_mrn"],
-  "content": ["{{prescriptionId}}",
+  "content": ["URR000012",
+              "{{prescriptionId}}",
               "{{patientId}}",
               "--",
               "active",

--- a/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
+++ b/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
@@ -36,6 +36,14 @@ export const renderTasksToString = (analyisis: any) => {
   return tasksStringList.join(',');
 };
 
+export const renderAssignmentsToString = (analyisis: any) => {
+  const assignmentsList = analyisis.assignments;
+  if (assignmentsList.length > 0) {
+    return assignmentsList.join(', ');
+  }
+  return EMPTY_FIELD;
+};
+
 const renderTasks = (tasks: string[]) =>
   tasks.length > 0
     ? tasks.map((task) => (

--- a/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
+++ b/src/views/Prescriptions/Search/components/table/PrescriptionTable/columns.tsx
@@ -39,7 +39,7 @@ export const renderTasksToString = (analyisis: any) => {
 export const renderAssignmentsToString = (analyisis: any) => {
   const assignmentsList = analyisis.assignments;
   if (assignmentsList.length > 0) {
-    return assignmentsList.join(', ');
+    return assignmentsList.join(',');
   }
   return EMPTY_FIELD;
 };

--- a/src/views/Prescriptions/utils/export.ts
+++ b/src/views/Prescriptions/utils/export.ts
@@ -31,7 +31,10 @@ import {
 import { TABLE_EMPTY_PLACE_HOLDER, TSV_EMPTY_PLACE_HOLDER } from 'utils/constants';
 import { downloadText } from 'utils/helper';
 
-import { renderTasksToString } from '../Search/components/table/PrescriptionTable/columns';
+import {
+  renderAssignmentsToString,
+  renderTasksToString,
+} from '../Search/components/table/PrescriptionTable/columns';
 
 export const ALL_KEYS = '*';
 export const MAX_VARIANTS_DOWNLOAD = 10000;
@@ -147,6 +150,9 @@ export const customMapping = (prefix: string, key: string, row: any, patientId: 
   } else if (prefix === 'PR' || prefix === 'RQ') {
     if (key === 'tasks') {
       return convertToPlain(renderTasksToString(row));
+    }
+    if (key === 'assignments') {
+      return convertToPlain(renderAssignmentsToString(row));
     }
   }
   return null;

--- a/src/views/Prescriptions/utils/tests/export.test.js
+++ b/src/views/Prescriptions/utils/tests/export.test.js
@@ -410,6 +410,36 @@ describe('customMapping CNV', () => {
   });
 });
 
+describe('customMapping PrescriptionTable', () => {
+  test('should map nothing', () => {
+    expect(customMapping(null, null, null)).toEqual(null);
+  });
+  test('should map assignments', () => {
+    const row = {
+      assignments: ['p1', 'p2'],
+    };
+    expect(customMapping('PR', 'assignments', row)).toEqual('p1,p2');
+  });
+  test('should map assignments empty array', () => {
+    const row = {
+      assignments: [],
+    };
+    expect(customMapping('PR', 'assignments', row)).toEqual('--');
+  });
+  test('should map tasks', () => {
+    const row = {
+      tasks: ['TEBA', 'TNEBA', 'GEBA'],
+    };
+    expect(customMapping('PR', 'tasks', row)).toEqual('TO,TN,G');
+  });
+  test('should map tasks empty array', () => {
+    const row = {
+      tasks: [],
+    };
+    expect(customMapping('PR', 'tasks', row)).toEqual('--');
+  });
+});
+
 describe('makeFilenameDatePart', () => {
   test('should format datetime', () => {
     const date = new Date(2020, 10, 31, 12, 42, 35);


### PR DESCRIPTION
# FIX : Afficher un double-tiret dans le TSV si pas d'assignation

- closes #CLIN-2962

## Description

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2962)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/assets/52966302/ba02797f-6bb7-4718-83a9-a6a18996be5e)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

